### PR TITLE
Make stream_settings optional in Inbound model

### DIFF
--- a/py3xui/inbound/inbound.py
+++ b/py3xui/inbound/inbound.py
@@ -59,7 +59,7 @@ class Inbound(BaseModel):
     port: int
     protocol: str
     settings: Settings
-    stream_settings: StreamSettings | str = Field(default="", alias=InboundFields.STREAM_SETTINGS)
+    stream_settings: StreamSettings | str = Field(default="", alias=InboundFields.STREAM_SETTINGS)  # type: ignore
     sniffing: Sniffing
 
     listen: str = ""

--- a/py3xui/inbound/inbound.py
+++ b/py3xui/inbound/inbound.py
@@ -42,7 +42,7 @@ class Inbound(BaseModel):
         port (int): The port number for the inbound connection. Required.
         protocol (str): The protocol for the inbound connection. Required.
         settings (Settings): The settings for the inbound connection. Required.
-        stream_settings (StreamSettings): The stream settings for the inbound connection. Required.
+        stream_settings (StreamSettings): The stream settings for the inbound connection. Optional.
         sniffing (Sniffing): The sniffing settings for the inbound connection. Required.
         listen (str): The listen address for the inbound connection. Optional.
         remark (str): The remark for the inbound connection. Optional.
@@ -59,7 +59,7 @@ class Inbound(BaseModel):
     port: int
     protocol: str
     settings: Settings
-    stream_settings: StreamSettings = Field(alias=InboundFields.STREAM_SETTINGS)  # type: ignore
+    stream_settings: StreamSettings | str = Field(default="", alias=InboundFields.STREAM_SETTINGS)
     sniffing: Sniffing
 
     listen: str = ""


### PR DESCRIPTION
Sometimes stream_settings can be an empty string, for example if inbound is socks proxy. Right now code methods related to inbound will fail if it's socks inbound. This pull request fixes it.

Code to reproduce:

```python
from py3xui import AsyncApi
import asyncio

async def main():
    api = AsyncApi.from_env()

    await api.login()

    inbounds = await api.inbound.get_list()
    print(inbounds)

asyncio.run(main())
```

Create a socks inbound and try running this code, it will fail with this exception:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Inbound
streamSettings
  Input should be a valid dictionary or instance of StreamSettings [type=model_type, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.9/v/model_type
```