### PR TITLE
Fix login for 3X-UI 3.0.X version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center" markdown>
 <img src="https://github.com/iwatkot/py3xui/assets/118521851/42c5d579-6202-4a9e-88f3-2d844fdd95b6">
 
-⚠️ The secret token feature was removed in the 3x-UI 2.6.0. ⚠️     
-The corresponding `token` parameter in the Api and AsyncApi constructors was removed in py3xui 0.5.0. This changed the order of constructor arguments, so please be aware of this change when updating the SDK.
+⚠️ The legacy secret token feature was removed in 3x-UI 2.6.0. ⚠️
+The synchronous `Api` also supports optional bearer token authentication with the `token` constructor argument or `XUI_TOKEN` environment variable for panels that expose token auth. `AsyncApi` still uses username/password login.
 
 Sync and Async Object-oriented Python SDK for the 3x-ui API.
 
@@ -71,6 +71,13 @@ api = Api.from_env()
 api = Api("http://your-3x-ui-host.com:2053", "your-username", "your-password")
 ```
 
+For synchronous token authentication, set `XUI_TOKEN` instead of `XUI_USERNAME` and `XUI_PASSWORD`, or pass `token` directly:
+```python
+from py3xui import Api
+
+api = Api("http://your-3x-ui-host.com:2053", token="your-api-token")
+```
+
 To work asynchronously:
 ```python
 from py3xui import AsyncApi
@@ -109,7 +116,7 @@ api = Api(
 This allows you to maintain TLS verification by providing a trusted certificate explicitly.
 
 ### Login
-No matter which API you're using or if was it created using environment variables or credentials, you'll need to call the `login` method to authenticate the user and save the cookie for future requests.
+When using username/password authentication, call the `login` method to authenticate the user and save the cookie for future requests. The synchronous API first fetches the CSRF token from the `csrf-token` endpoint and sends it with the login request. The asynchronous API reads the CSRF token from the login page before submitting credentials.
 ```python
 from py3xui import Api, AsyncApi
 
@@ -119,6 +126,8 @@ api.login()
 async_api = AsyncApi.from_env()
 await async_api.login()
 ```
+
+When the synchronous `Api` is created with `token` or `XUI_TOKEN`, do not call `login`; requests are authenticated with the `Authorization: Bearer ...` header.
 
 #### Using two-factor authentication
 If you enabled two-factor authentication in the 3x-ui app, you'll need to pass the two-factor code to the `login` method. The code can be either a string or an integer.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img src="https://github.com/iwatkot/py3xui/assets/118521851/42c5d579-6202-4a9e-88f3-2d844fdd95b6">
 
 ⚠️ The legacy secret token feature was removed in 3x-UI 2.6.0. ⚠️
-The synchronous `Api` also supports optional bearer token authentication with the `token` constructor argument or `XUI_TOKEN` environment variable for panels that expose token auth. `AsyncApi` still uses username/password login.
+The project also supports optional bearer token authentication with the `token` constructor argument or `XUI_TOKEN` environment variable for panels that expose token auth.
 
 Sync and Async Object-oriented Python SDK for the 3x-ui API.
 
@@ -116,7 +116,7 @@ api = Api(
 This allows you to maintain TLS verification by providing a trusted certificate explicitly.
 
 ### Login
-When using username/password authentication, call the `login` method to authenticate the user and save the cookie for future requests. The synchronous API first fetches the CSRF token from the `csrf-token` endpoint and sends it with the login request. The asynchronous API reads the CSRF token from the login page before submitting credentials.
+When using username/password authentication, call the `login` method to authenticate the user and save the cookie for future requests. The API first fetches the CSRF token from the `csrf-token` endpoint and sends it with the login request.
 ```python
 from py3xui import Api, AsyncApi
 

--- a/py3xui/api/README.md
+++ b/py3xui/api/README.md
@@ -369,8 +369,10 @@ It significantly increases the risk of security threats like man-in-the-middle a
 **Arguments**:
 
 - `host` _str_ - The XUI host URL.
-- `username` _str_ - The XUI username.
-- `password` _str_ - The XUI password.
+- `username` _str | None_ - The XUI username. Required when token is not provided.
+- `password` _str | None_ - The XUI password. Required when token is not provided.
+- `token` _str | None_ - The bearer token for API authentication. When provided,
+  login() is not required.
 - `use_tls_verify` _bool_ - Whether to verify the server TLS certificate.
 - `custom_certificate_path` _str | None_ - Path to a custom certificate file.
 - `logger` _Any | None_ - The logger, if not set, default logger is used.
@@ -380,6 +382,7 @@ It significantly increases the risk of security threats like man-in-the-middle a
 - `inbound` _InboundApi_ - The inbound API.
 - `database` _DatabaseApi_ - The database API.
 - `session` _str_ - The session cookie for the XUI API.
+- `csrf_token` _str | None_ - The CSRF token propagated to the sub-APIs.
 - `cookie_name` _str_ - The cookie name for the XUI API.
   
   Public Methods:
@@ -404,10 +407,35 @@ It significantly increases the risk of security threats like man-in-the-middle a
 
     api.login()
 
+    # Or use bearer token authentication without calling login().
+    api = py3xui.Api("https://xui.example.com", token="api-token")
+
     # Some examples of using the API.
     inbounds: list[py3xui.Inbound] = api.inbound.get_list()
     client: py3xui.Client = api.client.get_by_email("email")
     ```
+
+<a id="api.api.Api.csrf_token"></a>
+
+#### csrf\_token
+
+```python
+@property
+def csrf_token() -> str | None
+```
+
+The CSRF token shared by the sync sub-APIs after login.
+
+<a id="api.api.Api.csrf_token"></a>
+
+#### csrf\_token
+
+```python
+@csrf_token.setter
+def csrf_token(value: str | None) -> None
+```
+
+Sets the CSRF token on the sync client, inbound, database, and server APIs.
 
 <a id="api.api.Api.session"></a>
 
@@ -488,8 +516,9 @@ for SSL/TLS verification can be passed directly or read from environment variabl
 
 Following environment variables should be set:
 - XUI_HOST: The XUI host URL.
-- XUI_USERNAME: The XUI username.
-- XUI_PASSWORD: The XUI password.
+- XUI_USERNAME: The XUI username. Required when XUI_TOKEN is not set.
+- XUI_PASSWORD: The XUI password. Required when XUI_TOKEN is not set.
+- XUI_TOKEN: The bearer token for API authentication (Optional).
 - TLS_VERIFY: Whether to verify the server TLS certificate (Optional).
 - TLS_CERT_PATH: Path to a custom certificate file (Optional).
 
@@ -513,8 +542,8 @@ Following environment variables should be set:
     ```python
     import py3xui
 
-    api = py3xui.AsyncApi.from_env()
-    await api.login()
+    api = py3xui.Api.from_env()
+    api.login()
     ```
 
 <a id="api.api.Api.login"></a>
@@ -526,7 +555,9 @@ def login(two_factor_code: str | int | None = None) -> None
 ```
 
 Logs into the XUI API and sets the session cookie for the client, inbound, and
-database APIs.
+database APIs. Login fetches a CSRF token first and propagates it to all
+sub-APIs. If the API was created with a bearer token, use requests directly
+without calling login().
 
 **Arguments**:
 
@@ -1158,19 +1189,23 @@ Base class for the XUI API. Contains common methods for making requests.
 **Arguments**:
 
 - `host` _str_ - The host of the XUI API.
-- `username` _str_ - The username for the XUI API.
-- `password` _str_ - The password for the XUI API.
+- `username` _str | None_ - The username for the XUI API. Required when token is not provided.
+- `password` _str | None_ - The password for the XUI API. Required when token is not provided.
+- `token` _str | None_ - The bearer token for the XUI API. When provided,
+  login() is not required.
 - `use_tls_verify` _bool_ - Whether to verify the server TLS certificate.
 - `custom_certificate_path` _str | None_ - Path to a custom certificate file.
 - `logger` _Any | None_ - The logger, if not set, a dummy logger is used.
   
   Attributes and Properties:
 - `host` _str_ - The host of the XUI API.
-- `username` _str_ - The username for the XUI API.
-- `password` _str_ - The password for the XUI API.
+- `username` _str | None_ - The username for the XUI API.
+- `password` _str | None_ - The password for the XUI API.
+- `token` _str | None_ - The bearer token for the XUI API.
 - `use_tls_verify` _bool_ - Whether to verify the server TLS certificate.
 - `custom_certificate_path` _str | None_ - Path to a custom certificate file.
 - `max_retries` _int_ - The maximum number of retries for a request.
+- `csrf_token` _str | None_ - The CSRF token used with session authentication.
 - `session` _str_ - The session cookie for the XUI API.
 - `cookie_name` _str_ - The name of the cookie for the XUI API.
   
@@ -1205,7 +1240,7 @@ The host of the XUI API.
 
 ```python
 @property
-def username() -> str
+def username() -> str | None
 ```
 
 The username for the XUI API.
@@ -1220,7 +1255,7 @@ The username for the XUI API.
 
 ```python
 @property
-def password() -> str
+def password() -> str | None
 ```
 
 The password for the XUI API.
@@ -1228,6 +1263,32 @@ The password for the XUI API.
 **Returns**:
 
 - `str` - The password for the XUI API.
+
+<a id="api.api_base.BaseApi.token"></a>
+
+#### token
+
+```python
+@property
+def token() -> str | None
+```
+
+The bearer token for the XUI API.
+
+**Returns**:
+
+- `str | None` - The bearer token for the XUI API.
+
+<a id="api.api_base.BaseApi.token"></a>
+
+#### token
+
+```python
+@token.setter
+def token(value: str | None) -> None
+```
+
+Sets the bearer token for the XUI API.
 
 <a id="api.api_base.BaseApi.use_tls_verify"></a>
 
@@ -1288,6 +1349,36 @@ Sets the maximum number of retries for a request.
 **Arguments**:
 
 - `value` _int_ - The maximum number of retries for a request.
+
+<a id="api.api_base.BaseApi.csrf_token"></a>
+
+#### csrf\_token
+
+```python
+@property
+def csrf_token() -> str | None
+```
+
+The CSRF token for session-authenticated requests.
+
+**Returns**:
+
+  str | None: The CSRF token for the XUI API.
+
+<a id="api.api_base.BaseApi.csrf_token"></a>
+
+#### csrf\_token
+
+```python
+@csrf_token.setter
+def csrf_token(value: str | None) -> None
+```
+
+Sets the CSRF token for session-authenticated requests.
+
+**Arguments**:
+
+- `value` _str | None_ - The CSRF token for the XUI API.
 
 <a id="api.api_base.BaseApi.session"></a>
 
@@ -1359,6 +1450,10 @@ def login(two_factor_code: str | int | None = None) -> None
 
 Logs into the XUI API and sets the session cookie if successful.
 
+The login flow first fetches a CSRF token from the csrf-token endpoint, then
+sends that token with the username/password login request. The saved CSRF token
+is also sent on later requests when session authentication is used.
+
 **Arguments**:
 
 - `two_factor_code` _str | int | None_ - The two-factor authentication code, if required.
@@ -1366,6 +1461,7 @@ Logs into the XUI API and sets the session cookie if successful.
 
 **Raises**:
 
+- `RuntimeError` - If login is called when token authentication is already configured.
 - `ValueError` - If the login is unsuccessful.
 
 <a id="api.api_base.BaseApi.cookies"></a>

--- a/py3xui/api/api.py
+++ b/py3xui/api/api.py
@@ -76,7 +76,7 @@ class Api:
         custom_certificate_path: str | None = None,
         logger: Any | None = None,
         *,
-        token: str | None = None,  # The token is keyword for old version compbality
+        token: str | None = None,  # The token is keyword for old version compatibility
     ):  # pylint: disable=R0913, R0917
         self.logger = logger or logging.getLogger(__name__)
 

--- a/py3xui/api/api.py
+++ b/py3xui/api/api.py
@@ -72,10 +72,11 @@ class Api:
         host: str,
         username: str | None = None,
         password: str | None = None,
-        token: str | None = None,
         use_tls_verify: bool = True,
         custom_certificate_path: str | None = None,
         logger: Any | None = None,
+        *,
+        token: str | None = None,  # The token is keyword for old version compbality
     ):  # pylint: disable=R0913, R0917
         self.logger = logger or logging.getLogger(__name__)
 
@@ -225,10 +226,10 @@ class Api:
         """
         host = env.xui_host()
         token = env.xui_token()
-        is_token_found: bool = token is None
+        is_token_missing: bool = token is None
 
-        username = env.xui_username(raise_if_not_found=is_token_found)
-        password = env.xui_password(raise_if_not_found=is_token_found)
+        username = env.xui_username(raise_if_not_found=is_token_missing)
+        password = env.xui_password(raise_if_not_found=is_token_missing)
 
         if use_tls_verify is None:
             use_tls_verify = env.tls_verify()

--- a/py3xui/api/api.py
+++ b/py3xui/api/api.py
@@ -122,10 +122,18 @@ class Api:
 
     @property
     def csrf_token(self) -> str | None:
+        """The CSRF token shared by the underlying API clients.
+
+        Returns:
+            str | None: The CSRF token for session-authenticated requests."""
         return self._csrf_token
 
     @csrf_token.setter
     def csrf_token(self, value: str | None) -> None:
+        """Sets the CSRF token for all underlying API clients.
+
+        Arguments:
+            value (str | None): The CSRF token to propagate."""
         self._csrf_token = value
         self.client.csrf_token = value
         self.inbound.csrf_token = value
@@ -215,18 +223,12 @@ class Api:
             api.login()
             ```
         """
-        token = env.xui_token()
         host = env.xui_host()
-        username = env.parse_env(
-            keys=["XUI_USERNAME"],
-            postprocess_fn=lambda x: x,
-            raise_if_not_found=token is None,
-        )
-        password = env.parse_env(
-            keys=["XUI_PASSWORD"],
-            postprocess_fn=lambda x: x,
-            raise_if_not_found=token is None,
-        )
+        token = env.xui_token()
+        is_token_found: bool = token is None
+
+        username = env.xui_username(raise_if_not_found=is_token_found)
+        password = env.xui_password(raise_if_not_found=is_token_found)
 
         if use_tls_verify is None:
             use_tls_verify = env.tls_verify()

--- a/py3xui/api/api.py
+++ b/py3xui/api/api.py
@@ -25,8 +25,10 @@ class Api:
 
     Arguments:
         host (str): The XUI host URL.
-        username (str): The XUI username.
-        password (str): The XUI password.
+        username (str | None): The XUI username. Required when token is not provided.
+        password (str | None): The XUI password. Required when token is not provided.
+        token (str | None): The bearer token for API authentication. When provided,
+            login() is not required.
         use_tls_verify (bool): Whether to verify the server TLS certificate.
         custom_certificate_path (str | None): Path to a custom certificate file.
         logger (Any | None): The logger, if not set, default logger is used.
@@ -36,6 +38,7 @@ class Api:
         inbound (InboundApi): The inbound API.
         database (DatabaseApi): The database API.
         session (str): The session cookie for the XUI API.
+        csrf_token (str | None): The CSRF token propagated to the sub-APIs.
         cookie_name (str): The cookie name for the XUI API.
 
     Public Methods:
@@ -67,8 +70,9 @@ class Api:
     def __init__(
         self,
         host: str,
-        username: str,
-        password: str,
+        username: str | None = None,
+        password: str | None = None,
+        token: str | None = None,
         use_tls_verify: bool = True,
         custom_certificate_path: str | None = None,
         logger: Any | None = None,
@@ -76,19 +80,57 @@ class Api:
         self.logger = logger or logging.getLogger(__name__)
 
         self.client = ClientApi(
-            host, username, password, use_tls_verify, custom_certificate_path, logger
+            host,
+            username,
+            password,
+            token,
+            use_tls_verify,
+            custom_certificate_path,
+            logger,
         )
         self.inbound = InboundApi(
-            host, username, password, use_tls_verify, custom_certificate_path, logger
+            host,
+            username,
+            password,
+            token,
+            use_tls_verify,
+            custom_certificate_path,
+            logger,
         )
         self.database = DatabaseApi(
-            host, username, password, use_tls_verify, custom_certificate_path, logger
+            host,
+            username,
+            password,
+            token,
+            use_tls_verify,
+            custom_certificate_path,
+            logger,
         )
         self.server = ServerApi(
-            host, username, password, use_tls_verify, custom_certificate_path, logger
+            host,
+            username,
+            password,
+            token,
+            use_tls_verify,
+            custom_certificate_path,
+            logger,
         )
+
+        self._csrf_token: str | None = None
         self._session: str | None = None
         self._cookie_name: str | None = None
+
+    @property
+    def csrf_token(self) -> str | None:
+        return self._csrf_token
+
+    @csrf_token.setter
+    def csrf_token(self, value: str | None) -> None:
+        self._csrf_token = value
+        self.client.csrf_token = value
+        self.inbound.csrf_token = value
+        self.database.csrf_token = value
+        self.server.csrf_token = value
 
     @property
     def session(self) -> str | None:
@@ -148,8 +190,9 @@ class Api:
 
         Following environment variables should be set:
         - XUI_HOST: The XUI host URL.
-        - XUI_USERNAME: The XUI username.
-        - XUI_PASSWORD: The XUI password.
+        - XUI_USERNAME: The XUI username. Required when XUI_TOKEN is not set.
+        - XUI_PASSWORD: The XUI password. Required when XUI_TOKEN is not set.
+        - XUI_TOKEN: The bearer token for API authentication (Optional).
         - TLS_VERIFY: Whether to verify the server TLS certificate (Optional).
         - TLS_CERT_PATH: Path to a custom certificate file (Optional).
 
@@ -168,13 +211,22 @@ class Api:
             ```python
             import py3xui
 
-            api = py3xui.AsyncApi.from_env()
-            await api.login()
+            api = py3xui.Api.from_env()
+            api.login()
             ```
         """
+        token = env.xui_token()
         host = env.xui_host()
-        username = env.xui_username()
-        password = env.xui_password()
+        username = env.parse_env(
+            keys=["XUI_USERNAME"],
+            postprocess_fn=lambda x: x,
+            raise_if_not_found=token is None,
+        )
+        password = env.parse_env(
+            keys=["XUI_PASSWORD"],
+            postprocess_fn=lambda x: x,
+            raise_if_not_found=token is None,
+        )
 
         if use_tls_verify is None:
             use_tls_verify = env.tls_verify()
@@ -184,11 +236,21 @@ class Api:
         if custom_certificate_path is None:
             custom_certificate_path = env.tls_cert_path()
 
-        return cls(host, username, password, use_tls_verify, custom_certificate_path, logger)
+        return cls(
+            host,
+            username,
+            password,
+            token,
+            use_tls_verify,
+            custom_certificate_path,
+            logger,
+        )
 
     def login(self, two_factor_code: str | int | None = None) -> None:
         """Logs into the XUI API and sets the session cookie for the client, inbound, and
-        database APIs.
+        database APIs. Login fetches a CSRF token first and propagates it to all
+        sub-APIs. If the API was created with a bearer token, use requests directly
+        without calling login().
 
         Arguments:
             two_factor_code (str | int | None): The two-factor authentication code, if required.
@@ -206,4 +268,5 @@ class Api:
         self.client.login(two_factor_code)
         self.session = self.client.session  # type: ignore
         self.cookie_name = self.client.cookie_name
+        self.csrf_token = self.client.csrf_token
         self.logger.info("Logged in successfully.")

--- a/py3xui/api/api.py
+++ b/py3xui/api/api.py
@@ -243,10 +243,10 @@ class Api:
             host,
             username,
             password,
-            token,
             use_tls_verify,
             custom_certificate_path,
             logger,
+            token=token,
         )
 
     def login(self, two_factor_code: str | int | None = None) -> None:

--- a/py3xui/api/api.py
+++ b/py3xui/api/api.py
@@ -84,37 +84,37 @@ class Api:
             host,
             username,
             password,
-            token,
             use_tls_verify,
             custom_certificate_path,
             logger,
+            token=token,
         )
         self.inbound = InboundApi(
             host,
             username,
             password,
-            token,
             use_tls_verify,
             custom_certificate_path,
             logger,
+            token=token,
         )
         self.database = DatabaseApi(
             host,
             username,
             password,
-            token,
             use_tls_verify,
             custom_certificate_path,
             logger,
+            token=token,
         )
         self.server = ServerApi(
             host,
             username,
             password,
-            token,
             use_tls_verify,
             custom_certificate_path,
             logger,
+            token=token,
         )
 
         self._csrf_token: str | None = None

--- a/py3xui/api/api_base.py
+++ b/py3xui/api/api_base.py
@@ -67,10 +67,11 @@ class BaseApi:
         host: str,
         username: str | None = None,
         password: str | None = None,
-        token: str | None = None,
         use_tls_verify: bool = True,
         custom_certificate_path: str | None = None,
         logger: Any | None = None,
+        *,
+        token: str | None = None,
     ):  # pylint: disable=R0913, R0917
         self._host: str = host.rstrip("/")
         self._username: str | None = username

--- a/py3xui/api/api_base.py
+++ b/py3xui/api/api_base.py
@@ -3,6 +3,8 @@
 # pylint: disable=R0801
 
 import logging
+import re
+from html.parser import HTMLParser
 from time import sleep
 from typing import Any, Callable
 
@@ -22,6 +24,31 @@ class ApiFields:
     NO_IP_RECORD = "No IP Record"
     GET = "GET"
     POST = "POST"
+
+
+class _CsrfTokenParser(HTMLParser):
+    """Extracts CSRF tokens from login page HTML."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.token: str | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if self.token:
+            return
+
+        attrs_dict: dict[str, str] = {
+            name.lower(): value for name, value in attrs if value is not None
+        }
+
+        if tag.lower() == "input":
+            name = attrs_dict.get("name", "").lower()
+            if name in {"csrf", "csrf_token", "csrf-token", "csrftoken", "_csrf"}:
+                self.token = attrs_dict.get("value")
+        elif tag.lower() == "meta":
+            name = attrs_dict.get("name", "").lower()
+            if name == "csrf-token":
+                self.token = attrs_dict.get("content")
 
 
 # pylint: disable=R0902
@@ -165,6 +192,37 @@ class BaseApi:
             value (str | None): The name of the cookie for the XUI API."""
         self._cookie_name = value
 
+    @staticmethod
+    def _extract_csrf_token(page: str) -> str:
+        """Extracts csrf token from HTML login page
+
+        Arguments:
+            page (str): The web login page
+
+        Raises:
+            RuntimeError: if no CSRF token found
+
+        Returns:
+            str: The CSRF token found on the web page
+        """
+        parser = _CsrfTokenParser()
+        parser.feed(page)
+        if parser.token:
+            return parser.token
+
+        patterns: tuple[str, ...] = (
+            r'csrfToken["\']?\s*[:=]\s*["\']([^"\']+)',
+            r'csrf[_-]?token["\']?\s*[:=]\s*["\']([^"\']+)',
+            r'_csrf["\']?\s*[:=]\s*["\']([^"\']+)',
+        )
+
+        for pattern in patterns:
+            match = re.search(pattern, page, re.IGNORECASE)
+            if match:
+                return match.group(1)
+
+        raise RuntimeError("CSRF token not found on the page.")
+
     def login(self, two_factor_code: str | int | None = None) -> None:
         """Logs into the XUI API and sets the session cookie if successful.
 
@@ -184,11 +242,27 @@ class BaseApi:
 
         self.logger.info("Logging in with username: %s", self.username)
 
+        # Request to get cookie and CSRF token
+        response = self._get(self.host, headers, is_login=True)
+        response.raise_for_status()
+        self.session = self._get_cookie(response)
+
+        csrf_token: str = self._extract_csrf_token(response.text)
+        headers["X-CSRF-Token"] = csrf_token
+        headers["Origin"] = self.host
+
         response = self._post(url, headers, data, is_login=True)
         cookie = self._get_cookie(response)
+        if cookie is None:
+            cookie = self.session
+
         if not cookie:
-            raise ValueError("No session cookie found, something wrong with the login...")
-        self.logger.info("Session cookie successfully retrieved for username: %s", self.username)
+            raise ValueError(
+                "No session cookie found, something wrong with the login..."
+            )
+        self.logger.info(
+            "Session cookie successfully retrieved for username: %s", self.username
+        )
         self.session = cookie
 
     def _get_cookie(self, response: requests.Response) -> str | None:
@@ -265,6 +339,8 @@ class BaseApi:
             requests.exceptions.RequestException: If the request fails.
             requests.exceptions.RetryError: If the maximum number of retries is exceeded."""
         self.logger.debug("%s request to %s...", method.__name__.upper(), url)
+
+        is_login = kwargs.pop("is_login", False)
         for retry in range(1, self.max_retries + 1):
             try:
                 skip_check = kwargs.pop("skip_check", False)
@@ -295,13 +371,21 @@ class BaseApi:
                 response.raise_for_status()
                 if skip_check:
                     return response
-                self._check_response(response)
+                if not is_login:
+                    self._check_response(response)
                 return response
-            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+            ) as e:
                 if retry == self.max_retries:
                     raise e
                 self.logger.warning(
-                    "Request to %s failed: %s, retry %s of %s", url, e, retry, self.max_retries
+                    "Request to %s failed: %s, retry %s of %s",
+                    url,
+                    e,
+                    retry,
+                    self.max_retries,
                 )
                 sleep(1 * (retry + 1))
             except requests.exceptions.RequestException as e:
@@ -327,8 +411,12 @@ class BaseApi:
         Returns:
             requests.Response: The response from the XUI API."""
         if not kwargs.pop("is_login", False) and not self.session:
-            raise ValueError("Before making a POST request, you must use the login() method.")
-        return self._request_with_retry(requests.post, url, headers, json=data, **kwargs)
+            raise ValueError(
+                "Before making a POST request, you must use the login() method."
+            )
+        return self._request_with_retry(
+            requests.post, url, headers, json=data, **kwargs
+        )
 
     def _get(self, url: str, headers: dict[str, str], **kwargs) -> requests.Response:
         """Makes a GET request to the XUI API.
@@ -343,6 +431,8 @@ class BaseApi:
 
         Returns:
             requests.Response: The response from the XUI API."""
-        if not kwargs.pop("is_login", False) and not self.session:
-            raise ValueError("Before making a GET request, you must use the login() method.")
+        if not kwargs.get("is_login", False) and not self.session:
+            raise ValueError(
+                "Before making a GET request, you must use the login() method."
+            )
         return self._request_with_retry(requests.get, url, headers, **kwargs)

--- a/py3xui/api/api_base.py
+++ b/py3xui/api/api_base.py
@@ -11,6 +11,7 @@ import requests
 from py3xui.utils import COOKIE_NAMES
 
 
+# pylint: disable=too-few-public-methods
 class ApiFields:
     """Stores the fields returned by the XUI API for parsing."""
 
@@ -114,11 +115,15 @@ class BaseApi:
         """The token for the XUI API.
 
         Returns:
-            str: The token for the XUI API."""
+            str | None: The token for the XUI API."""
         return self._token
 
     @token.setter
     def token(self, value: str | None) -> None:
+        """Sets the bearer token for API authentication.
+
+        Arguments:
+            value (str | None): The bearer token to use for requests."""
         self._token = value
 
     @property
@@ -202,6 +207,10 @@ class BaseApi:
         self._cookie_name = value
 
     def _check_token_or_password(self) -> None:
+        """Validates that token auth or username/password auth is configured.
+
+        Raises:
+            ValueError: If neither a token nor username/password credentials are set."""
         if self.token:
             return
         if self.username and self.password:
@@ -209,6 +218,13 @@ class BaseApi:
         raise ValueError("There must be either token or username and password.")
 
     def _get_csrf_token(self) -> str:
+        """Fetches and stores a CSRF token for username/password login.
+
+        Returns:
+            str: The CSRF token returned by the XUI API.
+
+        Raises:
+            ValueError: If the csrf-token endpoint does not return a usable token."""
         endpoint: str = "csrf-token"
         headers: dict[str, str] = {}
 
@@ -248,6 +264,11 @@ class BaseApi:
 
         if None in (self._username, self._password):
             raise ValueError("No username or password entered.")
+
+        # Clear the session before new login
+        self.session = None
+        self.cookie_name = None
+        self.csrf_token = None
 
         headers: dict[str, str] = {"X-CSRF-Token": self._get_csrf_token()}
 
@@ -328,6 +349,13 @@ class BaseApi:
         return f"{self._host}/{endpoint}"
 
     def _generate_headers(self, headers: dict[str, str]) -> dict[str, str]:
+        """Adds authentication headers for token or session based requests.
+
+        Arguments:
+            headers (dict[str, str]): Existing request headers to extend.
+
+        Returns:
+            dict[str, str]: The headers with authentication fields added when available."""
         if self._token is not None:
             headers.update(
                 {"Authorization": f"Bearer {self._token}", "Accept": "application/json"}

--- a/py3xui/api/api_base.py
+++ b/py3xui/api/api_base.py
@@ -150,6 +150,14 @@ class BaseApi:
             int: The maximum number of retries for a request."""
         return self._max_retries
 
+    @max_retries.setter
+    def max_retries(self, value: int) -> None:
+        """Sets the maximum number of retries for a request.
+
+        Arguments:
+        value (int): The maximum number of retries for a request."""
+        self._max_retries = value
+
     @property
     def csrf_token(self) -> str | None:
         """The CSRF token for session-authenticated requests.
@@ -165,14 +173,6 @@ class BaseApi:
         Arguments:
             value (str | None): The CSRF token for the XUI API."""
         self._csrf_token = value
-
-    @max_retries.setter
-    def max_retries(self, value: int) -> None:
-        """Sets the maximum number of retries for a request.
-
-        Arguments:
-            value (int): The maximum number of retries for a request."""
-        self._max_retries = value
 
     @property
     def session(self) -> str | None:
@@ -275,9 +275,9 @@ class BaseApi:
         endpoint = "login"
         url = self._url(endpoint)
 
-        data: dict[str, str] = {  # pyright: ignore[reportAssignmentType]
-            "username": self.username,
-            "password": self.password,
+        data: dict[str, str] = {  # type: ignore # pyright: ignore[reportAssignmentType]
+            "username": self.username,  # type: ignore
+            "password": self.password,  # type: ignore
         }
 
         if two_factor_code is not None:
@@ -389,7 +389,7 @@ class BaseApi:
         self.logger.debug("%s request to %s...", method.__name__.upper(), url)
 
         if not kwargs.pop("is_csrf_request", False):
-            headers: dict[str, str] = self._generate_headers(headers)
+            headers = self._generate_headers(headers)
 
         for retry in range(1, self.max_retries + 1):
             try:

--- a/py3xui/api/api_base.py
+++ b/py3xui/api/api_base.py
@@ -236,12 +236,15 @@ class BaseApi:
             is_csrf_request=True,
             skip_check=True,
         )
-        self.session = self._get_cookie(response)
+
+        cookie: str | None = self._get_cookie(response)
+        if cookie is not None:
+            self.session = cookie
 
         response_json = response.json()
         csrf_token = response_json.get(ApiFields.OBJ)
         if not isinstance(csrf_token, str) or not csrf_token:
-            raise ValueError("No CSRF token found, something wrong with the login...")
+            raise ValueError("Cannot get CSRF code, something wrong with the login...")
         self.csrf_token = csrf_token
 
         return csrf_token

--- a/py3xui/api/api_base.py
+++ b/py3xui/api/api_base.py
@@ -3,8 +3,6 @@
 # pylint: disable=R0801
 
 import logging
-import re
-from html.parser import HTMLParser
 from time import sleep
 from typing import Any, Callable
 
@@ -13,7 +11,6 @@ import requests
 from py3xui.utils import COOKIE_NAMES
 
 
-# pylint: disable=too-few-public-methods
 class ApiFields:
     """Stores the fields returned by the XUI API for parsing."""
 
@@ -26,50 +23,29 @@ class ApiFields:
     POST = "POST"
 
 
-class _CsrfTokenParser(HTMLParser):
-    """Extracts CSRF tokens from login page HTML."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.token: str | None = None
-
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        if self.token:
-            return
-
-        attrs_dict: dict[str, str] = {
-            name.lower(): value for name, value in attrs if value is not None
-        }
-
-        if tag.lower() == "input":
-            name = attrs_dict.get("name", "").lower()
-            if name in {"csrf", "csrf_token", "csrf-token", "csrftoken", "_csrf"}:
-                self.token = attrs_dict.get("value")
-        elif tag.lower() == "meta":
-            name = attrs_dict.get("name", "").lower()
-            if name == "csrf-token":
-                self.token = attrs_dict.get("content")
-
-
 # pylint: disable=R0902
 class BaseApi:
     """Base class for the XUI API. Contains common methods for making requests.
 
     Arguments:
         host (str): The host of the XUI API.
-        username (str): The username for the XUI API.
-        password (str): The password for the XUI API.
+        username (str | None): The username for the XUI API. Required when token is not provided.
+        password (str | None): The password for the XUI API. Required when token is not provided.
+        token (str | None): The bearer token for the XUI API. When provided,
+            login() is not required.
         use_tls_verify (bool): Whether to verify the server TLS certificate.
         custom_certificate_path (str | None): Path to a custom certificate file.
         logger (Any | None): The logger, if not set, a dummy logger is used.
 
     Attributes and Properties:
         host (str): The host of the XUI API.
-        username (str): The username for the XUI API.
-        password (str): The password for the XUI API.
+        username (str | None): The username for the XUI API.
+        password (str | None): The password for the XUI API.
+        token (str | None): The bearer token for the XUI API.
         use_tls_verify (bool): Whether to verify the server TLS certificate.
         custom_certificate_path (str | None): Path to a custom certificate file.
         max_retries (int): The maximum number of retries for a request.
+        csrf_token (str | None): The CSRF token used with session authentication.
         session (str): The session cookie for the XUI API.
         cookie_name (str): The name of the cookie for the XUI API.
 
@@ -88,21 +64,26 @@ class BaseApi:
     def __init__(
         self,
         host: str,
-        username: str,
-        password: str,
+        username: str | None = None,
+        password: str | None = None,
+        token: str | None = None,
         use_tls_verify: bool = True,
         custom_certificate_path: str | None = None,
         logger: Any | None = None,
     ):  # pylint: disable=R0913, R0917
-        self._host = host.rstrip("/")
-        self._username = username
-        self._password = password
+        self._host: str = host.rstrip("/")
+        self._username: str | None = username
+        self._password: str | None = password
+        self._token: str | None = token
         self._use_tls_verify = use_tls_verify
         self._custom_certificate_path = custom_certificate_path
+        self._csrf_token: str | None = None
         self._max_retries: int = 3
         self._session: str | None = None
         self._cookie_name: str | None = None
         self.logger = logger or logging.getLogger(__name__)
+
+        self._check_token_or_password()
 
     @property
     def host(self) -> str:
@@ -113,7 +94,7 @@ class BaseApi:
         return self._host
 
     @property
-    def username(self) -> str:
+    def username(self) -> str | None:
         """The username for the XUI API.
 
         Returns:
@@ -121,12 +102,24 @@ class BaseApi:
         return self._username
 
     @property
-    def password(self) -> str:
+    def password(self) -> str | None:
         """The password for the XUI API.
 
         Returns:
             str: The password for the XUI API."""
         return self._password
+
+    @property
+    def token(self) -> str | None:
+        """The token for the XUI API.
+
+        Returns:
+            str: The token for the XUI API."""
+        return self._token
+
+    @token.setter
+    def token(self, value: str | None) -> None:
+        self._token = value
 
     @property
     def use_tls_verify(self) -> bool:
@@ -151,6 +144,22 @@ class BaseApi:
         Returns:
             int: The maximum number of retries for a request."""
         return self._max_retries
+
+    @property
+    def csrf_token(self) -> str | None:
+        """The CSRF token for session-authenticated requests.
+
+        Returns:
+            str | None: The CSRF token for the XUI API."""
+        return self._csrf_token
+
+    @csrf_token.setter
+    def csrf_token(self, value: str | None) -> None:
+        """Sets the CSRF token for session-authenticated requests.
+
+        Arguments:
+            value (str | None): The CSRF token for the XUI API."""
+        self._csrf_token = value
 
     @max_retries.setter
     def max_retries(self, value: int) -> None:
@@ -192,70 +201,71 @@ class BaseApi:
             value (str | None): The name of the cookie for the XUI API."""
         self._cookie_name = value
 
-    @staticmethod
-    def _extract_csrf_token(page: str) -> str:
-        """Extracts csrf token from HTML login page
+    def _check_token_or_password(self) -> None:
+        if self.token:
+            return
+        if self.username and self.password:
+            return
+        raise ValueError("There must be either token or username and password.")
 
-        Arguments:
-            page (str): The web login page
+    def _get_csrf_token(self) -> str:
+        endpoint: str = "csrf-token"
+        headers: dict[str, str] = {}
 
-        Raises:
-            RuntimeError: if no CSRF token found
-
-        Returns:
-            str: The CSRF token found on the web page
-        """
-        parser = _CsrfTokenParser()
-        parser.feed(page)
-        if parser.token:
-            return parser.token
-
-        patterns: tuple[str, ...] = (
-            r'csrfToken["\']?\s*[:=]\s*["\']([^"\']+)',
-            r'csrf[_-]?token["\']?\s*[:=]\s*["\']([^"\']+)',
-            r'_csrf["\']?\s*[:=]\s*["\']([^"\']+)',
+        url = self._url(endpoint)
+        response = self._get(
+            url,
+            headers,
+            is_login=True,
+            is_csrf_request=True,
+            skip_check=True,
         )
+        self.session = self._get_cookie(response)
 
-        for pattern in patterns:
-            match = re.search(pattern, page, re.IGNORECASE)
-            if match:
-                return match.group(1)
+        response_json = response.json()
+        csrf_token = response_json.get(ApiFields.OBJ)
+        if not isinstance(csrf_token, str) or not csrf_token:
+            raise ValueError("No CSRF token found, something wrong with the login...")
+        self.csrf_token = csrf_token
 
-        raise RuntimeError("CSRF token not found on the page.")
+        return csrf_token
 
     def login(self, two_factor_code: str | int | None = None) -> None:
         """Logs into the XUI API and sets the session cookie if successful.
+
+        The login flow first fetches a CSRF token from the csrf-token endpoint, then
+        sends that token with the username/password login request. The saved CSRF token
+        is also sent on later requests when session authentication is used.
 
         Arguments:
             two_factor_code (str | int | None): The two-factor authentication code, if required.
 
         Raises:
+            RuntimeError: If login is called when token authentication is already configured.
             ValueError: If the login is unsuccessful."""
-        endpoint = "login"
-        headers: dict[str, str] = {}
+        if self._token is not None:
+            raise RuntimeError("No need to login if using the token already.")
 
+        if None in (self._username, self._password):
+            raise ValueError("No username or password entered.")
+
+        headers: dict[str, str] = {"X-CSRF-Token": self._get_csrf_token()}
+
+        endpoint = "login"
         url = self._url(endpoint)
-        data = {"username": self.username, "password": self.password}
+
+        data: dict[str, str] = {  # pyright: ignore[reportAssignmentType]
+            "username": self.username,
+            "password": self.password,
+        }
 
         if two_factor_code is not None:
             data["twoFactorCode"] = str(two_factor_code)
 
         self.logger.info("Logging in with username: %s", self.username)
 
-        # Request to get cookie and CSRF token
-        response = self._get(self.host, headers, is_login=True)
-        response.raise_for_status()
-        self.session = self._get_cookie(response)
-
-        csrf_token: str = self._extract_csrf_token(response.text)
-        headers["X-CSRF-Token"] = csrf_token
-        headers["Origin"] = self.host
-
         response = self._post(url, headers, data, is_login=True)
         cookie = self._get_cookie(response)
-        if cookie is None:
-            cookie = self.session
-
         if not cookie:
             raise ValueError(
                 "No session cookie found, something wrong with the login..."
@@ -317,6 +327,16 @@ class BaseApi:
             str: The URL for the XUI API."""
         return f"{self._host}/{endpoint}"
 
+    def _generate_headers(self, headers: dict[str, str]) -> dict[str, str]:
+        if self._token is not None:
+            headers.update(
+                {"Authorization": f"Bearer {self._token}", "Accept": "application/json"}
+            )
+        elif self._csrf_token is not None:
+            headers.update({"X-CSRF-Token": self._csrf_token})
+
+        return headers
+
     def _request_with_retry(
         self,
         method: Callable[..., requests.Response],
@@ -340,7 +360,9 @@ class BaseApi:
             requests.exceptions.RetryError: If the maximum number of retries is exceeded."""
         self.logger.debug("%s request to %s...", method.__name__.upper(), url)
 
-        is_login = kwargs.pop("is_login", False)
+        if not kwargs.pop("is_csrf_request", False):
+            headers: dict[str, str] = self._generate_headers(headers)
+
         for retry in range(1, self.max_retries + 1):
             try:
                 skip_check = kwargs.pop("skip_check", False)
@@ -371,8 +393,7 @@ class BaseApi:
                 response.raise_for_status()
                 if skip_check:
                     return response
-                if not is_login:
-                    self._check_response(response)
+                self._check_response(response)
                 return response
             except (
                 requests.exceptions.ConnectionError,
@@ -410,9 +431,13 @@ class BaseApi:
 
         Returns:
             requests.Response: The response from the XUI API."""
-        if not kwargs.pop("is_login", False) and not self.session:
+        if (
+            not kwargs.pop("is_login", False)
+            and not self.session
+            and self.token is None
+        ):
             raise ValueError(
-                "Before making a POST request, you must use the login() method."
+                "Before making a POST request, you must use the login() method or use the token."
             )
         return self._request_with_retry(
             requests.post, url, headers, json=data, **kwargs
@@ -431,8 +456,12 @@ class BaseApi:
 
         Returns:
             requests.Response: The response from the XUI API."""
-        if not kwargs.get("is_login", False) and not self.session:
+        if (
+            not kwargs.pop("is_login", False)
+            and not self.session
+            and self.token is None
+        ):
             raise ValueError(
-                "Before making a GET request, you must use the login() method."
+                "Before making a GET request, you must use the login() method or use the token."
             )
         return self._request_with_retry(requests.get, url, headers, **kwargs)

--- a/py3xui/api/api_base.py
+++ b/py3xui/api/api_base.py
@@ -155,7 +155,7 @@ class BaseApi:
         """Sets the maximum number of retries for a request.
 
         Arguments:
-        value (int): The maximum number of retries for a request."""
+            value (int): The maximum number of retries for a request."""
         self._max_retries = value
 
     @property

--- a/py3xui/async_api/README.md
+++ b/py3xui/async_api/README.md
@@ -460,7 +460,8 @@ async def login(two_factor_code: str | int | None = None) -> None
 ```
 
 Logs into the XUI API and sets the session cookie for the client, inbound, and
-database APIs.
+database APIs. Login reads the CSRF token from the panel login page and sends
+it with the username/password login request.
 
 **Arguments**:
 
@@ -990,6 +991,9 @@ async def login(two_factor_code: str | int | None = None) -> None
 ```
 
 Logs into the XUI API and sets the session cookie if successful.
+
+The login flow reads a CSRF token from the panel login page, then sends that
+token with the username/password login request.
 
 **Arguments**:
 

--- a/py3xui/async_api/README.md
+++ b/py3xui/async_api/README.md
@@ -460,8 +460,7 @@ async def login(two_factor_code: str | int | None = None) -> None
 ```
 
 Logs into the XUI API and sets the session cookie for the client, inbound, and
-database APIs. Login reads the CSRF token from the panel login page and sends
-it with the username/password login request.
+database APIs. Login gets the CSRF token from '/csrf-token' endpoint. 
 
 **Arguments**:
 

--- a/py3xui/async_api/async_api.py
+++ b/py3xui/async_api/async_api.py
@@ -79,7 +79,7 @@ class AsyncApi:
         logger: Any | None = None,
         *,
         token: str
-        | None = None,  # The token is keyword for complability with older versions
+        | None = None,  # The token is keyword for compatibility with older versions
     ):  # pylint: disable=R0913, R0917
         self.logger = logger or logging.getLogger(__name__)
 
@@ -87,37 +87,37 @@ class AsyncApi:
             host,
             username,
             password,
-            token,
             use_tls_verify,
             custom_certificate_path,
             logger,
+            token=token,
         )
         self.inbound = AsyncInboundApi(
             host,
             username,
             password,
-            token,
             use_tls_verify,
             custom_certificate_path,
             logger,
+            token=token,
         )
         self.database = AsyncDatabaseApi(
             host,
             username,
             password,
-            token,
             use_tls_verify,
             custom_certificate_path,
             logger,
+            token=token,
         )
         self.server = AsyncServerApi(
             host,
             username,
             password,
-            token,
             use_tls_verify,
             custom_certificate_path,
             logger,
+            token=token,
         )
         self._csrf_token: str | None = None
         self._session: str | None = None

--- a/py3xui/async_api/async_api.py
+++ b/py3xui/async_api/async_api.py
@@ -72,8 +72,9 @@ class AsyncApi:
     def __init__(
         self,
         host: str,
-        username: str,
-        password: str,
+        username: str | None = None,
+        password: str | None = None,
+        token: str | None = None,
         use_tls_verify: bool = True,
         custom_certificate_path: str | None = None,
         logger: Any | None = None,
@@ -81,19 +82,65 @@ class AsyncApi:
         self.logger = logger or logging.getLogger(__name__)
 
         self.client = AsyncClientApi(
-            host, username, password, use_tls_verify, custom_certificate_path, logger
+            host,
+            username,
+            password,
+            token,
+            use_tls_verify,
+            custom_certificate_path,
+            logger,
         )
         self.inbound = AsyncInboundApi(
-            host, username, password, use_tls_verify, custom_certificate_path, logger
+            host,
+            username,
+            password,
+            token,
+            use_tls_verify,
+            custom_certificate_path,
+            logger,
         )
         self.database = AsyncDatabaseApi(
-            host, username, password, use_tls_verify, custom_certificate_path, logger
+            host,
+            username,
+            password,
+            token,
+            use_tls_verify,
+            custom_certificate_path,
+            logger,
         )
         self.server = AsyncServerApi(
-            host, username, password, use_tls_verify, custom_certificate_path, logger
+            host,
+            username,
+            password,
+            token,
+            use_tls_verify,
+            custom_certificate_path,
+            logger,
         )
+        self._csrf_token: str | None = None
         self._session: str | None = None
         self._cookie_name: str | None = None
+
+    @property
+    def csrf_token(self) -> str | None:
+        """The csrf token for the XUI API.
+
+        Returns:
+            str: The csrf token for the XUI API.
+        """
+        return self._csrf_token
+
+    @csrf_token.setter
+    def csrf_token(self, value: str | None) -> None:
+        """Sets the csrf token for the XUI API.
+
+        Arguments:
+            value (str | None): The csrf token to set."""
+        self._csrf_token = value
+        self.client.csrf_token = value
+        self.inbound.csrf_token = value
+        self.database.csrf_token = value
+        self.server.csrf_token = value
 
     @property
     def session(self) -> str | None:
@@ -178,8 +225,11 @@ class AsyncApi:
             ```
         """
         host = env.xui_host()
-        username = env.xui_username()
-        password = env.xui_password()
+        token = env.xui_token()
+        is_token_found: bool = token is None
+
+        username = env.xui_username(raise_if_not_found=is_token_found)
+        password = env.xui_password(raise_if_not_found=is_token_found)
 
         if use_tls_verify is None:
             use_tls_verify = env.tls_verify()
@@ -189,11 +239,20 @@ class AsyncApi:
         if custom_certificate_path is None:
             custom_certificate_path = env.tls_cert_path()
 
-        return cls(host, username, password, use_tls_verify, custom_certificate_path, logger)
+        return cls(
+            host,
+            username,
+            password,
+            token,
+            use_tls_verify,
+            custom_certificate_path,
+            logger,
+        )
 
     async def login(self, two_factor_code: str | int | None = None) -> None:
         """Logs into the XUI API and sets the session cookie for the client, inbound, and
-        database APIs.
+        database APIs. Login reads the CSRF token from the panel login page and sends
+        it with the username/password login request.
 
         Arguments:
             two_factor_code (str | int | None): The two-factor authentication code, if required.
@@ -209,5 +268,6 @@ class AsyncApi:
         """
         await self.client.login(two_factor_code)
         self.session = self.client.session  # type: ignore
+        self.csrf_token = self.client.csrf_token
         self.cookie_name = self.client.cookie_name
         self.logger.info("Logged in successfully.")

--- a/py3xui/async_api/async_api.py
+++ b/py3xui/async_api/async_api.py
@@ -245,10 +245,10 @@ class AsyncApi:
             host,
             username,
             password,
-            token,
             use_tls_verify,
             custom_certificate_path,
             logger,
+            token=token,
         )
 
     async def login(self, two_factor_code: str | int | None = None) -> None:

--- a/py3xui/async_api/async_api.py
+++ b/py3xui/async_api/async_api.py
@@ -74,10 +74,12 @@ class AsyncApi:
         host: str,
         username: str | None = None,
         password: str | None = None,
-        token: str | None = None,
         use_tls_verify: bool = True,
         custom_certificate_path: str | None = None,
         logger: Any | None = None,
+        *,
+        token: str
+        | None = None,  # The token is keyword for complability with older versions
     ):  # pylint: disable=R0913, R0917
         self.logger = logger or logging.getLogger(__name__)
 
@@ -226,10 +228,10 @@ class AsyncApi:
         """
         host = env.xui_host()
         token = env.xui_token()
-        is_token_found: bool = token is None
+        is_token_missing: bool = token is None
 
-        username = env.xui_username(raise_if_not_found=is_token_found)
-        password = env.xui_password(raise_if_not_found=is_token_found)
+        username = env.xui_username(raise_if_not_found=is_token_missing)
+        password = env.xui_password(raise_if_not_found=is_token_missing)
 
         if use_tls_verify is None:
             use_tls_verify = env.tls_verify()

--- a/py3xui/async_api/async_api_base.py
+++ b/py3xui/async_api/async_api_base.py
@@ -313,7 +313,7 @@ class AsyncBaseApi:
         response_json = response.json()
         csrf_token = response_json.get(ApiFields.OBJ)
         if not isinstance(csrf_token, str) or not csrf_token:
-            raise ValueError("No CSRF token found, something wrong with the login...")
+            raise ValueError("Cannot get CSRF token, something wrong with the login...")
         self.csrf_token = csrf_token
 
         return csrf_token
@@ -432,8 +432,8 @@ class AsyncBaseApi:
             and self.token is None
         ):
             raise ValueError(
-                "Before making a POST request, you must use the login() method.\
-                Or use token authentication."
+                "Before making a POST request, you must use the login() method.",
+                "Or use token authentication.",
             )
         return await self._request_with_retry(
             ApiFields.POST, url, headers, json=data, **kwargs
@@ -457,7 +457,7 @@ class AsyncBaseApi:
             and self.token is None
         ):
             raise ValueError(
-                "Before making a POST request, you must use the login() method.\
-                Or use token authentication."
+                "Before making a POST request, you must use the login() method.",
+                "Or use token authentication.",
             )
         return await self._request_with_retry(ApiFields.GET, url, headers, **kwargs)

--- a/py3xui/async_api/async_api_base.py
+++ b/py3xui/async_api/async_api_base.py
@@ -3,13 +3,40 @@
 # pylint: disable=R0801
 
 import asyncio
+from html.parser import HTMLParser
 import logging
+import re
 from typing import Any
 
 import httpx
 
 from py3xui.api.api_base import ApiFields
 from py3xui.utils import COOKIE_NAMES
+
+
+class _CsrfTokenParser(HTMLParser):
+    """Extracts CSRF tokens from login page HTML."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.token: str | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if self.token:
+            return
+
+        attrs_dict: dict[str, str] = {
+            name.lower(): value for name, value in attrs if value is not None
+        }
+
+        if tag.lower() == "input":
+            name = attrs_dict.get("name", "").lower()
+            if name in {"csrf", "csrf_token", "csrf-token", "csrftoken", "_csrf"}:
+                self.token = attrs_dict.get("value")
+        elif tag.lower() == "meta":
+            name = attrs_dict.get("name", "").lower()
+            if name == "csrf-token":
+                self.token = attrs_dict.get("content")
 
 
 # pylint: disable=R0902
@@ -186,6 +213,8 @@ class AsyncBaseApi:
             httpx.RequestError: If the request fails.
             httpx.HTTPStatusError: If the maximum number of retries is exceeded."""
         self.logger.debug("%s request to %s...", method, url)
+
+        is_login = kwargs.pop("is_login", False)
         for retry in range(1, self.max_retries + 1):
             try:
                 skip_check = kwargs.pop("skip_check", False)
@@ -223,18 +252,56 @@ class AsyncBaseApi:
                 response.raise_for_status()
                 if skip_check:
                     return response
-                await self._check_response(response)
+                if not is_login:
+                    await self._check_response(response)
                 return response
             except (httpx.RequestError, httpx.TimeoutException) as e:
                 if retry == self.max_retries:
                     raise e
                 self.logger.warning(
-                    "Request to %s failed: %s, retry %s of %s", url, e, retry, self.max_retries
+                    "Request to %s failed: %s, retry %s of %s",
+                    url,
+                    e,
+                    retry,
+                    self.max_retries,
                 )
                 await asyncio.sleep(1 * (retry + 1))
             except httpx.HTTPStatusError as e:
                 raise e
-        raise ConnectionError(f"Max retries exceeded with no successful response to {url}")
+        raise ConnectionError(
+            f"Max retries exceeded with no successful response to {url}"
+        )
+
+    @staticmethod
+    def _extract_csrf_token(page: str) -> str:
+        """Extracts csrf token from HTML login page
+
+        Arguments:
+            page (str): The web login page
+
+        Raises:
+            RuntimeError: if no CSRF token found
+
+        Returns:
+            str: The CSRF token found on the web page
+        """
+        parser = _CsrfTokenParser()
+        parser.feed(page)
+        if parser.token:
+            return parser.token
+
+        patterns: tuple[str, ...] = (
+            r'csrfToken["\']?\s*[:=]\s*["\']([^"\']+)',
+            r'csrf[_-]?token["\']?\s*[:=]\s*["\']([^"\']+)',
+            r'_csrf["\']?\s*[:=]\s*["\']([^"\']+)',
+        )
+
+        for pattern in patterns:
+            match = re.search(pattern, page, re.IGNORECASE)
+            if match:
+                return match.group(1)
+
+        raise RuntimeError("CSRF token not found on the page.")
 
     async def login(self, two_factor_code: str | int | None = None) -> None:
         """Logs into the XUI API and sets the session cookie if successful.
@@ -255,11 +322,24 @@ class AsyncBaseApi:
 
         self.logger.info("Logging in with username: %s", self.username)
 
+        # Request to get cookie and CSRF token
+        response = await self._get(self.host, headers, is_login=True)
+        response.raise_for_status()
+        self.session = await self._get_cookie(response)
+
+        csrf_token: str = self._extract_csrf_token(response.text)
+        headers["X-CSRF-Token"] = csrf_token
+        headers["Origin"] = self.host
+
         response = await self._post(url, headers, data, is_login=True)
         cookie = await self._get_cookie(response)
         if not cookie:
-            raise ValueError("No session cookie found, something wrong with the login...")
-        self.logger.info("Session cookie successfully retrieved for username: %s", self.username)
+            raise ValueError(
+                "No session cookie found, something wrong with the login..."
+            )
+        self.logger.info(
+            "Session cookie successfully retrieved for username: %s", self.username
+        )
         self.session = cookie
 
     async def _get_cookie(self, response: httpx.Response) -> str | None:
@@ -322,8 +402,12 @@ class AsyncBaseApi:
         Returns:
             httpx.Response: The response from the XUI API."""
         if not kwargs.pop("is_login", False) and not self.session:
-            raise ValueError("Before making a POST request, you must use the login() method.")
-        return await self._request_with_retry(ApiFields.POST, url, headers, json=data, **kwargs)
+            raise ValueError(
+                "Before making a POST request, you must use the login() method."
+            )
+        return await self._request_with_retry(
+            ApiFields.POST, url, headers, json=data, **kwargs
+        )
 
     async def _get(self, url: str, headers: dict[str, str], **kwargs) -> httpx.Response:
         """Makes a GET request to the XUI API.
@@ -337,6 +421,8 @@ class AsyncBaseApi:
 
         Returns:
             httpx.Response: The response from the XUI API."""
-        if not kwargs.pop("is_login", False) and not self.session:
-            raise ValueError("Before making a POST request, you must use the login() method.")
+        if not kwargs.get("is_login", False) and not self.session:
+            raise ValueError(
+                "Before making a POST request, you must use the login() method."
+            )
         return await self._request_with_retry(ApiFields.GET, url, headers, **kwargs)

--- a/py3xui/async_api/async_api_base.py
+++ b/py3xui/async_api/async_api_base.py
@@ -231,7 +231,7 @@ class AsyncBaseApi:
         self.logger.debug("%s request to %s...", method, url)
 
         if not kwargs.pop("is_csrf_request", False):
-            headers: dict[str, str] = self._generate_headers(headers)
+            headers = self._generate_headers(headers)
 
         for retry in range(1, self.max_retries + 1):
             try:
@@ -346,9 +346,9 @@ class AsyncBaseApi:
         endpoint = "login"
         url = self._url(endpoint)
 
-        data: dict[str, str] = {  # pyright: ignore[reportAssignmentType]
-            "username": self.username,
-            "password": self.password,
+        data: dict[str, str] = {  # type: ignore # pyright: ignore[reportAssignmentType]
+            "username": self.username,  # type: ignore
+            "password": self.password,  # type: ignore
         }
 
         if two_factor_code is not None:

--- a/py3xui/async_api/async_api_base.py
+++ b/py3xui/async_api/async_api_base.py
@@ -51,10 +51,11 @@ class AsyncBaseApi:
         host: str,
         username: str | None = None,
         password: str | None = None,
-        token: str | None = None,
         use_tls_verify: bool = True,
         custom_certificate_path: str | None = None,
         logger: Any | None = None,
+        *,
+        token: str | None = None,
     ):  # pylint: disable=R0913, R0917
         self._host: str = host.rstrip("/")
         self._username: str | None = username
@@ -308,7 +309,10 @@ class AsyncBaseApi:
             is_csrf_request=True,
             skip_check=True,
         )
-        self.session = await self._get_cookie(response)
+
+        cookie = await self._get_cookie(response)
+        if cookie:
+            self.session = cookie
 
         response_json = response.json()
         csrf_token = response_json.get(ApiFields.OBJ)
@@ -432,7 +436,7 @@ class AsyncBaseApi:
             and self.token is None
         ):
             raise ValueError(
-                "Before making a POST request, you must use the login() method.",
+                "Before making a POST request, you must use the login() method. "
                 "Or use token authentication.",
             )
         return await self._request_with_retry(
@@ -457,7 +461,7 @@ class AsyncBaseApi:
             and self.token is None
         ):
             raise ValueError(
-                "Before making a POST request, you must use the login() method.",
+                "Before making a POST request, you must use the login() method. "
                 "Or use token authentication.",
             )
         return await self._request_with_retry(ApiFields.GET, url, headers, **kwargs)

--- a/py3xui/async_api/async_api_base.py
+++ b/py3xui/async_api/async_api_base.py
@@ -321,7 +321,7 @@ class AsyncBaseApi:
     async def login(self, two_factor_code: str | int | None = None) -> None:
         """Logs into the XUI API and sets the session cookie if successful.
 
-        The login flow reads a CSRF token from the panel login page, then sends that
+        The login flow reads a CSRF token from the `csrf-token' endpoint, then sends that
         token with the username/password login request.
 
         Arguments:
@@ -432,7 +432,7 @@ class AsyncBaseApi:
             and self.token is None
         ):
             raise ValueError(
-                "Before making a POST request, you must use the login() method."
+                "Before making a POST request, you must use the login() method. Or use token authentication."
             )
         return await self._request_with_retry(
             ApiFields.POST, url, headers, json=data, **kwargs
@@ -456,6 +456,6 @@ class AsyncBaseApi:
             and self.token is None
         ):
             raise ValueError(
-                "Before making a POST request, you must use the login() method."
+                "Before making a POST request, you must use the login() method. Or use token authentication."
             )
         return await self._request_with_retry(ApiFields.GET, url, headers, **kwargs)

--- a/py3xui/async_api/async_api_base.py
+++ b/py3xui/async_api/async_api_base.py
@@ -432,7 +432,8 @@ class AsyncBaseApi:
             and self.token is None
         ):
             raise ValueError(
-                "Before making a POST request, you must use the login() method. Or use token authentication."
+                "Before making a POST request, you must use the login() method.\
+                Or use token authentication."
             )
         return await self._request_with_retry(
             ApiFields.POST, url, headers, json=data, **kwargs
@@ -456,6 +457,7 @@ class AsyncBaseApi:
             and self.token is None
         ):
             raise ValueError(
-                "Before making a POST request, you must use the login() method. Or use token authentication."
+                "Before making a POST request, you must use the login() method.\
+                Or use token authentication."
             )
         return await self._request_with_retry(ApiFields.GET, url, headers, **kwargs)

--- a/py3xui/async_api/async_api_base.py
+++ b/py3xui/async_api/async_api_base.py
@@ -3,40 +3,13 @@
 # pylint: disable=R0801
 
 import asyncio
-from html.parser import HTMLParser
 import logging
-import re
 from typing import Any
 
 import httpx
 
 from py3xui.api.api_base import ApiFields
 from py3xui.utils import COOKIE_NAMES
-
-
-class _CsrfTokenParser(HTMLParser):
-    """Extracts CSRF tokens from login page HTML."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.token: str | None = None
-
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        if self.token:
-            return
-
-        attrs_dict: dict[str, str] = {
-            name.lower(): value for name, value in attrs if value is not None
-        }
-
-        if tag.lower() == "input":
-            name = attrs_dict.get("name", "").lower()
-            if name in {"csrf", "csrf_token", "csrf-token", "csrftoken", "_csrf"}:
-                self.token = attrs_dict.get("value")
-        elif tag.lower() == "meta":
-            name = attrs_dict.get("name", "").lower()
-            if name == "csrf-token":
-                self.token = attrs_dict.get("content")
 
 
 # pylint: disable=R0902
@@ -76,21 +49,26 @@ class AsyncBaseApi:
     def __init__(
         self,
         host: str,
-        username: str,
-        password: str,
+        username: str | None = None,
+        password: str | None = None,
+        token: str | None = None,
         use_tls_verify: bool = True,
         custom_certificate_path: str | None = None,
         logger: Any | None = None,
     ):  # pylint: disable=R0913, R0917
-        self._host = host.rstrip("/")
-        self._username = username
-        self._password = password
+        self._host: str = host.rstrip("/")
+        self._username: str | None = username
+        self._password: str | None = password
+        self._token: str | None = token
         self._use_tls_verify = use_tls_verify
         self._custom_certificate_path = custom_certificate_path
+        self._csrf_token: str | None = None
         self._max_retries: int = 3
         self._session: str | None = None
         self._cookie_name: str | None = None
         self.logger = logger or logging.getLogger(__name__)
+
+        self._check_token_or_password()
 
     @property
     def host(self) -> str:
@@ -101,7 +79,7 @@ class AsyncBaseApi:
         return self._host
 
     @property
-    def username(self) -> str:
+    def username(self) -> str | None:
         """The username for the XUI API.
 
         Returns:
@@ -109,12 +87,40 @@ class AsyncBaseApi:
         return self._username
 
     @property
-    def password(self) -> str:
+    def password(self) -> str | None:
         """The password for the XUI API.
 
         Returns:
             str: The password for the XUI API."""
         return self._password
+
+    @property
+    def csrf_token(self) -> str | None:
+        """The CSRF token for session-authenticated requests.
+
+        Returns:
+            str | None: The CSRF token for the XUI API."""
+        return self._csrf_token
+
+    @csrf_token.setter
+    def csrf_token(self, value: str | None) -> None:
+        """Sets the CSRF token for session-authenticated requests.
+
+        Arguments:
+            value (str | None): The CSRF token for the XUI API."""
+        self._csrf_token = value
+
+    @property
+    def token(self) -> str | None:
+        """The token for the XUI API.
+
+        Returns:
+            str: The token for the XUI API."""
+        return self._token
+
+    @token.setter
+    def token(self, value: str | None) -> None:
+        self._token = value
 
     @property
     def use_tls_verify(self) -> bool:
@@ -190,6 +196,16 @@ class AsyncBaseApi:
             str: The URL for the XUI API."""
         return f"{self._host}/{endpoint}"
 
+    def _generate_headers(self, headers: dict[str, str]) -> dict[str, str]:
+        if self._token is not None:
+            headers.update(
+                {"Authorization": f"Bearer {self._token}", "Accept": "application/json"}
+            )
+        elif self._csrf_token is not None:
+            headers.update({"X-CSRF-Token": self._csrf_token})
+
+        return headers
+
     async def _request_with_retry(
         self,
         method: str,
@@ -214,7 +230,9 @@ class AsyncBaseApi:
             httpx.HTTPStatusError: If the maximum number of retries is exceeded."""
         self.logger.debug("%s request to %s...", method, url)
 
-        is_login = kwargs.pop("is_login", False)
+        if not kwargs.pop("is_csrf_request", False):
+            headers: dict[str, str] = self._generate_headers(headers)
+
         for retry in range(1, self.max_retries + 1):
             try:
                 skip_check = kwargs.pop("skip_check", False)
@@ -252,8 +270,7 @@ class AsyncBaseApi:
                 response.raise_for_status()
                 if skip_check:
                     return response
-                if not is_login:
-                    await self._check_response(response)
+                await self._check_response(response)
                 return response
             except (httpx.RequestError, httpx.TimeoutException) as e:
                 if retry == self.max_retries:
@@ -272,64 +289,72 @@ class AsyncBaseApi:
             f"Max retries exceeded with no successful response to {url}"
         )
 
-    @staticmethod
-    def _extract_csrf_token(page: str) -> str:
-        """Extracts csrf token from HTML login page
+    def _check_token_or_password(self) -> None:
+        if self.token:
+            return
+        if self.username and self.password:
+            return
+        raise ValueError("There must be either token or username and password.")
 
-        Arguments:
-            page (str): The web login page
+    async def _get_csrf_token(self) -> str:
+        endpoint: str = "csrf-token"
+        headers: dict[str, str] = {}
 
-        Raises:
-            RuntimeError: if no CSRF token found
-
-        Returns:
-            str: The CSRF token found on the web page
-        """
-        parser = _CsrfTokenParser()
-        parser.feed(page)
-        if parser.token:
-            return parser.token
-
-        patterns: tuple[str, ...] = (
-            r'csrfToken["\']?\s*[:=]\s*["\']([^"\']+)',
-            r'csrf[_-]?token["\']?\s*[:=]\s*["\']([^"\']+)',
-            r'_csrf["\']?\s*[:=]\s*["\']([^"\']+)',
+        url = self._url(endpoint)
+        response = await self._get(
+            url,
+            headers,
+            is_login=True,
+            is_csrf_request=True,
+            skip_check=True,
         )
+        self.session = await self._get_cookie(response)
 
-        for pattern in patterns:
-            match = re.search(pattern, page, re.IGNORECASE)
-            if match:
-                return match.group(1)
+        response_json = response.json()
+        csrf_token = response_json.get(ApiFields.OBJ)
+        if not isinstance(csrf_token, str) or not csrf_token:
+            raise ValueError("No CSRF token found, something wrong with the login...")
+        self.csrf_token = csrf_token
 
-        raise RuntimeError("CSRF token not found on the page.")
+        return csrf_token
 
     async def login(self, two_factor_code: str | int | None = None) -> None:
         """Logs into the XUI API and sets the session cookie if successful.
+
+        The login flow reads a CSRF token from the panel login page, then sends that
+        token with the username/password login request.
 
         Arguments:
             two_factor_code (str | int | None): The two-factor authentication code, if required.
 
         Raises:
             ValueError: If the login is unsuccessful."""
-        endpoint = "login"
-        headers: dict[str, str] = {}
 
+        if self._token is not None:
+            raise RuntimeError("No need to login if using the token already.")
+
+        if None in (self._username, self._password):
+            raise ValueError("No username or password entered.")
+
+        # Clear the session before new login
+        self.session = None
+        self.cookie_name = None
+        self.csrf_token = None
+
+        headers: dict[str, str] = {"X-CSRF-Token": await self._get_csrf_token()}
+
+        endpoint = "login"
         url = self._url(endpoint)
-        data = {"username": self.username, "password": self.password}
+
+        data: dict[str, str] = {  # pyright: ignore[reportAssignmentType]
+            "username": self.username,
+            "password": self.password,
+        }
 
         if two_factor_code is not None:
             data["twoFactorCode"] = str(two_factor_code)
 
         self.logger.info("Logging in with username: %s", self.username)
-
-        # Request to get cookie and CSRF token
-        response = await self._get(self.host, headers, is_login=True)
-        response.raise_for_status()
-        self.session = await self._get_cookie(response)
-
-        csrf_token: str = self._extract_csrf_token(response.text)
-        headers["X-CSRF-Token"] = csrf_token
-        headers["Origin"] = self.host
 
         response = await self._post(url, headers, data, is_login=True)
         cookie = await self._get_cookie(response)
@@ -401,7 +426,11 @@ class AsyncBaseApi:
 
         Returns:
             httpx.Response: The response from the XUI API."""
-        if not kwargs.pop("is_login", False) and not self.session:
+        if (
+            not kwargs.pop("is_login", False)
+            and not self.session
+            and self.token is None
+        ):
             raise ValueError(
                 "Before making a POST request, you must use the login() method."
             )
@@ -421,7 +450,11 @@ class AsyncBaseApi:
 
         Returns:
             httpx.Response: The response from the XUI API."""
-        if not kwargs.get("is_login", False) and not self.session:
+        if (
+            not kwargs.pop("is_login", False)
+            and not self.session
+            and self.token is None
+        ):
             raise ValueError(
                 "Before making a POST request, you must use the login() method."
             )

--- a/py3xui/utils/README.md
+++ b/py3xui/utils/README.md
@@ -59,7 +59,7 @@ Get the XUI host from the environment using the following keys:
 #### xui\_username
 
 ```python
-def xui_username(raise_if_not_found: bool = False) -> str
+def xui_username(raise_if_not_found: bool = False) -> str | None
 ```
 
 Get the XUI username from the environment using the following keys:
@@ -84,7 +84,7 @@ Get the XUI username from the environment using the following keys:
 #### xui\_password
 
 ```python
-def xui_password(raise_if_not_found: bool = False) -> str
+def xui_password(raise_if_not_found: bool = False) -> str | None
 ```
 
 Get the XUI password from the environment using the following keys:

--- a/py3xui/utils/README.md
+++ b/py3xui/utils/README.md
@@ -94,6 +94,20 @@ Get the XUI password from the environment using the following keys:
 
   str | None: The XUI password or None
 
+<a id="utils.env.xui_token"></a>
+
+#### xui\_token
+
+```python
+def xui_token() -> str | None
+```
+
+Get the optional XUI API token from the environment.
+
+**Returns**:
+
+  str | None: The XUI API token or None if not set.
+
 <a id="utils.env.tls_verify"></a>
 
 #### tls\_verify
@@ -123,4 +137,3 @@ Get the path to the TLS certificate from the environment using the following key
 **Returns**:
 
   str | None: The path to the TLS certificate file, or None if not set.
-

--- a/py3xui/utils/README.md
+++ b/py3xui/utils/README.md
@@ -59,11 +59,16 @@ Get the XUI host from the environment using the following keys:
 #### xui\_username
 
 ```python
-def xui_username() -> str
+def xui_username(raise_if_not_found: bool = False) -> str
 ```
 
 Get the XUI username from the environment using the following keys:
 - XUI_USERNAME
+
+**Arguments**:
+
+- `raise_if_not_found` _bool_ - Whether to raise an error if `XUI_USERNAME`
+  is not found. Defaults to False.
 
 **Raises**:
 
@@ -79,11 +84,16 @@ Get the XUI username from the environment using the following keys:
 #### xui\_password
 
 ```python
-def xui_password() -> str
+def xui_password(raise_if_not_found: bool = False) -> str
 ```
 
 Get the XUI password from the environment using the following keys:
 - XUI_PASSWORD
+
+**Arguments**:
+
+- `raise_if_not_found` _bool_ - Whether to raise an error if `XUI_PASSWORD`
+  is not found. Defaults to False.
 
 **Raises**:
 

--- a/py3xui/utils/README.md
+++ b/py3xui/utils/README.md
@@ -59,7 +59,7 @@ Get the XUI host from the environment using the following keys:
 #### xui\_username
 
 ```python
-def xui_username(raise_if_not_found: bool = False) -> str | None
+def xui_username(raise_if_not_found: bool = True) -> str | None
 ```
 
 Get the XUI username from the environment using the following keys:
@@ -68,7 +68,7 @@ Get the XUI username from the environment using the following keys:
 **Arguments**:
 
 - `raise_if_not_found` _bool_ - Whether to raise an error if `XUI_USERNAME`
-  is not found. Defaults to False.
+  is not found. Defaults to True.
 
 **Raises**:
 
@@ -84,7 +84,7 @@ Get the XUI username from the environment using the following keys:
 #### xui\_password
 
 ```python
-def xui_password(raise_if_not_found: bool = False) -> str | None
+def xui_password(raise_if_not_found: bool = True) -> str | None
 ```
 
 Get the XUI password from the environment using the following keys:
@@ -93,7 +93,7 @@ Get the XUI password from the environment using the following keys:
 **Arguments**:
 
 - `raise_if_not_found` _bool_ - Whether to raise an error if `XUI_PASSWORD`
-  is not found. Defaults to False.
+  is not found. Defaults to True.
 
 **Raises**:
 

--- a/py3xui/utils/env.py
+++ b/py3xui/utils/env.py
@@ -48,35 +48,45 @@ def xui_host() -> str:
     )
 
 
-def xui_username() -> str:
+def xui_username(raise_if_not_found: bool = False) -> str | None:
     """Get the XUI username from the environment using the following keys:
     - XUI_USERNAME
 
+    Arguments:
+        raise_if_not_found (bool): Whether to raise an error if XUI_USERNAME is not set.
+            Defaults to False because token authentication does not require a username.
+
     Raises:
-        ValueError: If none of the keys are found in the environment
+        ValueError: If none of the keys are found and raise_if_not_found is True.
 
     Returns:
-        str | None: The XUI username or None
+        str | None: The XUI username or None.
     """
     return parse_env(
         keys=["XUI_USERNAME"],
         postprocess_fn=lambda x: x,
+        raise_if_not_found=raise_if_not_found,
     )
 
 
-def xui_password() -> str:
+def xui_password(raise_if_not_found: bool = False) -> str | None:
     """Get the XUI password from the environment using the following keys:
     - XUI_PASSWORD
 
+    Arguments:
+        raise_if_not_found (bool): Whether to raise an error if XUI_PASSWORD is not set.
+            Defaults to False because token authentication does not require a password.
+
     Raises:
-        ValueError: If none of the keys are found in the environment
+        ValueError: If none of the keys are found and raise_if_not_found is True.
 
     Returns:
-        str | None: The XUI password or None
+        str | None: The XUI password or None.
     """
     return parse_env(
         keys=["XUI_PASSWORD"],
         postprocess_fn=lambda x: x,
+        raise_if_not_found=raise_if_not_found,
     )
 
 

--- a/py3xui/utils/env.py
+++ b/py3xui/utils/env.py
@@ -54,7 +54,7 @@ def xui_username(raise_if_not_found: bool = True) -> str | None:
 
     Arguments:
         raise_if_not_found (bool): Whether to raise an error if XUI_USERNAME is not set.
-            Defaults to False because token authentication does not require a username.
+            Defaults to True.
 
     Raises:
         ValueError: If none of the keys are found and raise_if_not_found is True.
@@ -75,7 +75,7 @@ def xui_password(raise_if_not_found: bool = True) -> str | None:
 
     Arguments:
         raise_if_not_found (bool): Whether to raise an error if XUI_PASSWORD is not set.
-            Defaults to False because token authentication does not require a password.
+            Defaults to True.
 
     Raises:
         ValueError: If none of the keys are found and raise_if_not_found is True.

--- a/py3xui/utils/env.py
+++ b/py3xui/utils/env.py
@@ -5,7 +5,9 @@ from typing import Any, Callable
 
 
 def parse_env(
-    keys: list[str], postprocess_fn: Callable[[str], Any], raise_if_not_found: bool = True
+    keys: list[str],
+    postprocess_fn: Callable[[str], Any],
+    raise_if_not_found: bool = True,
 ) -> Any:
     """Parse the environment for the first key that is found and return the value after
     postprocessing it.
@@ -75,6 +77,17 @@ def xui_password() -> str:
     return parse_env(
         keys=["XUI_PASSWORD"],
         postprocess_fn=lambda x: x,
+    )
+
+
+def xui_token() -> str | None:
+    """Get the optional XUI API token from the environment.
+
+    Returns:
+        str | None: The XUI API token or None if not set.
+    """
+    return parse_env(
+        keys=["XUI_TOKEN"], postprocess_fn=lambda x: x, raise_if_not_found=False
     )
 
 

--- a/py3xui/utils/env.py
+++ b/py3xui/utils/env.py
@@ -48,7 +48,7 @@ def xui_host() -> str:
     )
 
 
-def xui_username(raise_if_not_found: bool = False) -> str | None:
+def xui_username(raise_if_not_found: bool = True) -> str | None:
     """Get the XUI username from the environment using the following keys:
     - XUI_USERNAME
 
@@ -69,7 +69,7 @@ def xui_username(raise_if_not_found: bool = False) -> str | None:
     )
 
 
-def xui_password(raise_if_not_found: bool = False) -> str | None:
+def xui_password(raise_if_not_found: bool = True) -> str | None:
     """Get the XUI password from the environment using the following keys:
     - XUI_PASSWORD
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "requests>=2.0.0",
     "httpx>=0.20.0",
+    "mypy>=2.1.0",
 ]
 
 [project.urls]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,7 +16,6 @@ USERNAME = "admin"
 PASSWORD = "admin"
 SESSION = "abc123"
 EMAIL = "alhtim2x"
-SESSION = "abc123"
 CSRF_TOKEN = "test-csrf-token"
 TOKEN = "test-api-token"
 CSRF_RESPONSE = {ApiFields.SUCCESS: True, ApiFields.OBJ: CSRF_TOKEN}
@@ -25,11 +24,17 @@ CSRF_RESPONSE = {ApiFields.SUCCESS: True, ApiFields.OBJ: CSRF_TOKEN}
 def test_login_success():
     with requests_mock.Mocker() as m:
         m.get(f"{HOST}/csrf-token", json=CSRF_RESPONSE, cookies={"3x-ui": SESSION})
-        m.post(f"{HOST}/login", json={ApiFields.SUCCESS: True}, cookies={"3x-ui": SESSION})
+        m.post(
+            f"{HOST}/login", json={ApiFields.SUCCESS: True}, cookies={"3x-ui": SESSION}
+        )
         api = Api(HOST, "username", "password")
         api.login()
-        assert api.client.session == SESSION, f"Expected {SESSION}, got {api.client.session}"
-        assert api.csrf_token == CSRF_TOKEN, f"Expected {CSRF_TOKEN}, got {api.csrf_token}"
+        assert api.client.session == SESSION, (
+            f"Expected {SESSION}, got {api.client.session}"
+        )
+        assert api.csrf_token == CSRF_TOKEN, (
+            f"Expected {CSRF_TOKEN}, got {api.csrf_token}"
+        )
         assert api.inbound.csrf_token == CSRF_TOKEN
         assert m.request_history[1].headers["X-CSRF-Token"] == CSRF_TOKEN
 
@@ -63,7 +68,9 @@ def test_logged_in_requests_include_csrf_header():
 
     with requests_mock.Mocker() as m:
         m.get(f"{HOST}/csrf-token", json=CSRF_RESPONSE, cookies={"3x-ui": SESSION})
-        m.post(f"{HOST}/login", json={ApiFields.SUCCESS: True}, cookies={"3x-ui": SESSION})
+        m.post(
+            f"{HOST}/login", json={ApiFields.SUCCESS: True}, cookies={"3x-ui": SESSION}
+        )
         m.get(f"{HOST}/panel/api/inbounds/list", json=response_example)
 
         api = Api(HOST, "username", "password")
@@ -81,8 +88,12 @@ def test_from_env(monkeypatch: pytest.MonkeyPatch):
 
     api = Api.from_env()
     assert api.inbound.host == HOST, f"Expected {HOST}, got {api.inbound.host}"
-    assert api.inbound.username == USERNAME, f"Expected {USERNAME}, got {api.inbound.username}"
-    assert api.inbound.password == PASSWORD, f"Expected {PASSWORD}, got {api.inbound.password}"
+    assert api.inbound.username == USERNAME, (
+        f"Expected {USERNAME}, got {api.inbound.username}"
+    )
+    assert api.inbound.password == PASSWORD, (
+        f"Expected {PASSWORD}, got {api.inbound.password}"
+    )
     assert api.inbound.token is None
 
 
@@ -145,16 +156,16 @@ def test_get_inbounds():
         assert len(inbounds) == 1, f"Expected 1, got {len(inbounds)}"
         inbound = inbounds[0]
         assert isinstance(inbound, Inbound), f"Expected Inbound, got {type(inbound)}"
-        assert isinstance(
-            inbound.stream_settings, (StreamSettings, str)
-        ), f"Expected StreamSettings or str, got {type(inbound.stream_settings)}"
+        assert isinstance(inbound.stream_settings, (StreamSettings, str)), (
+            f"Expected StreamSettings or str, got {type(inbound.stream_settings)}"
+        )
 
-        assert isinstance(
-            inbound.sniffing, Sniffing
-        ), f"Expected Sniffing, got {type(inbound.sniffing)}"
-        assert isinstance(
-            inbound.client_stats[0], Client
-        ), f"Expected ClientStats, got {type(inbound.client_stats[0])}"
+        assert isinstance(inbound.sniffing, Sniffing), (
+            f"Expected Sniffing, got {type(inbound.sniffing)}"
+        )
+        assert isinstance(inbound.client_stats[0], Client), (
+            f"Expected ClientStats, got {type(inbound.client_stats[0])}"
+        )
 
         assert inbound.id == 1, f"Expected 1, got {inbound.id}"
 
@@ -167,7 +178,9 @@ def _prepare_inbound() -> Inbound:
         "acceptProxyProtocol": False,
         "header": {"type": "none"},
     }
-    stream_settings = StreamSettings(security="reality", network="tcp", tcp_settings=tcp_settings)
+    stream_settings = StreamSettings(
+        security="reality", network="tcp", tcp_settings=tcp_settings
+    )
 
     inbound = Inbound(
         enable=True,
@@ -201,7 +214,10 @@ def test_delete_inbound_failed():
     with requests_mock.Mocker() as m:
         m.post(
             f"{HOST}/panel/api/inbounds/del/1",
-            json={ApiFields.SUCCESS: False, ApiFields.MSG: "Delete Failed: record not found"},
+            json={
+                ApiFields.SUCCESS: False,
+                ApiFields.MSG: "Delete Failed: record not found",
+            },
         )
         api = Api(HOST, USERNAME, PASSWORD)
         api.session = SESSION
@@ -221,7 +237,10 @@ def test_get_client():
     response_example = json.load(open(os.path.join(RESPONSES_DIR, "get_client.json")))
 
     with requests_mock.Mocker() as m:
-        m.get(f"{HOST}/panel/api/inbounds/getClientTraffics/{EMAIL}", json=response_example)
+        m.get(
+            f"{HOST}/panel/api/inbounds/getClientTraffics/{EMAIL}",
+            json=response_example,
+        )
         api = Api(HOST, USERNAME, PASSWORD)
         api.session = SESSION
         client = api.client.get_by_email(EMAIL)
@@ -257,7 +276,8 @@ def test_update_client():
     client = Client(id=str(uuid.uuid4()), email="test", enable=True)
     with requests_mock.Mocker() as m:
         m.post(
-            f"{HOST}/panel/api/inbounds/updateClient/{client.id}", json={ApiFields.SUCCESS: True}
+            f"{HOST}/panel/api/inbounds/updateClient/{client.id}",
+            json={ApiFields.SUCCESS: True},
         )
         api = Api(HOST, USERNAME, PASSWORD)
         api.session = SESSION
@@ -266,7 +286,10 @@ def test_update_client():
 
 def test_reset_client_ips():
     with requests_mock.Mocker() as m:
-        m.post(f"{HOST}/panel/api/inbounds/clearClientIps/{EMAIL}", json={ApiFields.SUCCESS: True})
+        m.post(
+            f"{HOST}/panel/api/inbounds/clearClientIps/{EMAIL}",
+            json={ApiFields.SUCCESS: True},
+        )
         api = Api(HOST, USERNAME, PASSWORD)
         api.session = SESSION
         api.client.reset_ips(EMAIL)
@@ -274,7 +297,10 @@ def test_reset_client_ips():
 
 def test_reset_inbounds_stats():
     with requests_mock.Mocker() as m:
-        m.post(f"{HOST}/panel/api/inbounds/resetAllTraffics", json={ApiFields.SUCCESS: True})
+        m.post(
+            f"{HOST}/panel/api/inbounds/resetAllTraffics",
+            json={ApiFields.SUCCESS: True},
+        )
         api = Api(HOST, USERNAME, PASSWORD)
         api.session = SESSION
         api.inbound.reset_stats()
@@ -283,7 +309,8 @@ def test_reset_inbounds_stats():
 def test_reset_inbound_client_stats():
     with requests_mock.Mocker() as m:
         m.post(
-            f"{HOST}/panel/api/inbounds/resetAllClientTraffics/1", json={ApiFields.SUCCESS: True}
+            f"{HOST}/panel/api/inbounds/resetAllClientTraffics/1",
+            json={ApiFields.SUCCESS: True},
         )
         api = Api(HOST, USERNAME, PASSWORD)
         api.session = SESSION
@@ -303,7 +330,9 @@ def test_reset_client_stats():
 
 def test_delete_client():
     with requests_mock.Mocker() as m:
-        m.post(f"{HOST}/panel/api/inbounds/1/delClient/1", json={ApiFields.SUCCESS: True})
+        m.post(
+            f"{HOST}/panel/api/inbounds/1/delClient/1", json={ApiFields.SUCCESS: True}
+        )
         api = Api(HOST, USERNAME, PASSWORD)
         api.session = SESSION
         api.client.delete(1, "1")
@@ -311,7 +340,10 @@ def test_delete_client():
 
 def test_delete_depleted_clients():
     with requests_mock.Mocker() as m:
-        m.post(f"{HOST}/panel/api/inbounds/delDepletedClients/1", json={ApiFields.SUCCESS: True})
+        m.post(
+            f"{HOST}/panel/api/inbounds/delDepletedClients/1",
+            json={ApiFields.SUCCESS: True},
+        )
         api = Api(HOST, USERNAME, PASSWORD)
         api.session = SESSION
         api.client.delete_depleted(1)
@@ -326,7 +358,9 @@ def test_client_online():
 
 
 def test_get_client_traffic_by_id():
-    response_example = json.load(open(os.path.join(RESPONSES_DIR, "get_client_traffic_by_id.json")))
+    response_example = json.load(
+        open(os.path.join(RESPONSES_DIR, "get_client_traffic_by_id.json"))
+    )
     with requests_mock.Mocker() as m:
         m.get(
             f"{HOST}/panel/api/inbounds/getClientTrafficsById/239708ef-487e-4945-829d-ad79a0ce067e",
@@ -358,7 +392,9 @@ def test_get_status():
     """
     Test for get_status() method of ServerApi class
     """
-    response_example = json.load(open(os.path.join(RESPONSES_DIR, "get_server_status.json")))
+    response_example = json.load(
+        open(os.path.join(RESPONSES_DIR, "get_server_status.json"))
+    )
 
     with requests_mock.Mocker() as m:
         m.get(f"{HOST}/panel/api/server/status", json=response_example)
@@ -368,10 +404,12 @@ def test_get_status():
         status = api.server.get_status()
 
         assert status.cpu == 5.2, f"Expected CPU 5.2%, got {status.cpu}%"
-        assert (
-            status.mem.current == 1024000
-        ), f"Expected current memory 1024000, got {status.mem.current}"
-        assert status.mem.total == 8192000, f"Expected total memory 8192000, got {status.mem.total}"
+        assert status.mem.current == 1024000, (
+            f"Expected current memory 1024000, got {status.mem.current}"
+        )
+        assert status.mem.total == 8192000, (
+            f"Expected total memory 8192000, got {status.mem.total}"
+        )
 
 
 def test_get_db():
@@ -395,7 +433,9 @@ def test_get_db():
         # Check saved file contents
         with open(save_path, "rb") as f:
             saved_content = f.read()
-        assert saved_content == test_content, f"Expected {test_content}, got {saved_content}"
+        assert saved_content == test_content, (
+            f"Expected {test_content}, got {saved_content}"
+        )
 
         # Remove test file
         import os
@@ -451,7 +491,10 @@ def test_get_xray_version_available():
     }
 
     with requests_mock.Mocker() as m:
-        m.get(f"{HOST}/panel/api/server/getXrayVersion", json=response_example_xray_available)
+        m.get(
+            f"{HOST}/panel/api/server/getXrayVersion",
+            json=response_example_xray_available,
+        )
 
         api = Api(HOST, USERNAME, PASSWORD)
         api.session = SESSION
@@ -473,7 +516,10 @@ def test_get_xray_version_unavailable():
     }
 
     with requests_mock.Mocker() as m:
-        m.get(f"{HOST}/panel/api/server/getXrayVersion", json=response_example_xray_unavailable)
+        m.get(
+            f"{HOST}/panel/api/server/getXrayVersion",
+            json=response_example_xray_unavailable,
+        )
 
         api = Api(HOST, USERNAME, PASSWORD)
         api.session = SESSION
@@ -517,8 +563,12 @@ def test_install_new_xray_version_failed():
     }
 
     with requests_mock.Mocker() as m:
-        # 
-        m.post(f"{HOST}/panel/api/server/installXray/1.5.0", json=response_example, status_code=400)
+        #
+        m.post(
+            f"{HOST}/panel/api/server/installXray/1.5.0",
+            json=response_example,
+            status_code=400,
+        )
 
         api = Api(HOST, USERNAME, PASSWORD)
         api.session = SESSION
@@ -543,12 +593,17 @@ def test_update_geofile():
 
         assert m.called, "Mocked request was not called"
 
+
 def test_update_geofile_failed():
     """
     Test for updating geofile failure
     """
     with requests_mock.Mocker() as m:
-        m.post(f"{HOST}/panel/api/server/updateGeofile", json={ApiFields.SUCCESS: False}, status_code=400)
+        m.post(
+            f"{HOST}/panel/api/server/updateGeofile",
+            json={ApiFields.SUCCESS: False},
+            status_code=400,
+        )
 
         api = Api(HOST, USERNAME, PASSWORD)
         api.session = SESSION
@@ -563,7 +618,9 @@ def test_get_server_config():
     """
     Test for getting server config
     """
-    response_example = json.load(open(os.path.join(RESPONSES_DIR, "get_server_config.json")))
+    response_example = json.load(
+        open(os.path.join(RESPONSES_DIR, "get_server_config.json"))
+    )
 
     with requests_mock.Mocker() as m:
         m.get(f"{HOST}/panel/api/server/getConfigJson", json=response_example)
@@ -574,7 +631,12 @@ def test_get_server_config():
         config = api.server.get_server_config()
 
         assert config is not None, "Expected config, got None"
-        assert isinstance(config.inbounds, list), f"Expected list of inbounds, got {type(config.inbounds)}"
-        assert config.log.access == "none", f"Expected access log 'none', got {config.log.access}"
+        assert isinstance(config.inbounds, list), (
+            f"Expected list of inbounds, got {type(config.inbounds)}"
+        )
+        assert config.log.access == "none", (
+            f"Expected access log 'none', got {config.log.access}"
+        )
+
 
 # endregion

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,36 +18,80 @@ SESSION = "abc123"
 EMAIL = "alhtim2x"
 SESSION = "abc123"
 CSRF_TOKEN = "test-csrf-token"
-CSRF_PAGE = f'<input type="hidden" name="csrf_token" value="{CSRF_TOKEN}">'
+TOKEN = "test-api-token"
+CSRF_RESPONSE = {ApiFields.SUCCESS: True, ApiFields.OBJ: CSRF_TOKEN}
 
 
 def test_login_success():
     with requests_mock.Mocker() as m:
-        m.get(HOST, text=CSRF_PAGE)
+        m.get(f"{HOST}/csrf-token", json=CSRF_RESPONSE, cookies={"3x-ui": SESSION})
         m.post(f"{HOST}/login", json={ApiFields.SUCCESS: True}, cookies={"3x-ui": SESSION})
         api = Api(HOST, "username", "password")
         api.login()
         assert api.client.session == SESSION, f"Expected {SESSION}, got {api.client.session}"
+        assert api.csrf_token == CSRF_TOKEN, f"Expected {CSRF_TOKEN}, got {api.csrf_token}"
+        assert api.inbound.csrf_token == CSRF_TOKEN
+        assert m.request_history[1].headers["X-CSRF-Token"] == CSRF_TOKEN
 
 
 def test_login_failed():
     with requests_mock.Mocker() as m:
-        m.get(HOST, text=CSRF_PAGE)
+        m.get(f"{HOST}/csrf-token", json=CSRF_RESPONSE, cookies={"3x-ui": SESSION})
         m.post(f"{HOST}/login", json={ApiFields.SUCCESS: False})
         api = Api(HOST, "username", "password")
         with pytest.raises(ValueError):
             api.client.login()
 
 
-def test_from_env():
-    os.environ["XUI_HOST"] = HOST
-    os.environ["XUI_USERNAME"] = USERNAME
-    os.environ["XUI_PASSWORD"] = PASSWORD
+def test_from_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("XUI_HOST", HOST)
+    monkeypatch.setenv("XUI_USERNAME", USERNAME)
+    monkeypatch.setenv("XUI_PASSWORD", PASSWORD)
+    monkeypatch.delenv("XUI_TOKEN", raising=False)
 
     api = Api.from_env()
     assert api.inbound.host == HOST, f"Expected {HOST}, got {api.inbound.host}"
     assert api.inbound.username == USERNAME, f"Expected {USERNAME}, got {api.inbound.username}"
     assert api.inbound.password == PASSWORD, f"Expected {PASSWORD}, got {api.inbound.password}"
+    assert api.inbound.token is None
+
+
+def test_from_env_token(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("XUI_HOST", HOST)
+    monkeypatch.setenv("XUI_TOKEN", TOKEN)
+    monkeypatch.delenv("XUI_USERNAME", raising=False)
+    monkeypatch.delenv("XUI_PASSWORD", raising=False)
+
+    api = Api.from_env()
+    assert api.inbound.host == HOST, f"Expected {HOST}, got {api.inbound.host}"
+    assert api.inbound.username is None
+    assert api.inbound.password is None
+    assert api.inbound.token == TOKEN
+
+
+def test_token_auth_uses_authorization_header():
+    response_example = json.load(open(os.path.join(RESPONSES_DIR, "get_inbounds.json")))
+
+    with requests_mock.Mocker() as m:
+        m.get(f"{HOST}/panel/api/inbounds/list", json=response_example)
+        api = Api(HOST, token=TOKEN)
+        inbounds = api.inbound.get_list()
+
+        assert len(inbounds) == 1, f"Expected 1, got {len(inbounds)}"
+        assert m.last_request.headers["Authorization"] == f"Bearer {TOKEN}"
+        assert m.last_request.headers["Accept"] == "application/json"
+
+
+def test_login_rejected_with_token():
+    api = Api(HOST, token=TOKEN)
+
+    with pytest.raises(RuntimeError):
+        api.login()
+
+
+def test_credentials_or_token_required():
+    with pytest.raises(ValueError):
+        Api(HOST)
 
 
 def test_get_inbounds():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,10 +17,13 @@ PASSWORD = "admin"
 SESSION = "abc123"
 EMAIL = "alhtim2x"
 SESSION = "abc123"
+CSRF_TOKEN = "test-csrf-token"
+CSRF_PAGE = f'<input type="hidden" name="csrf_token" value="{CSRF_TOKEN}">'
 
 
 def test_login_success():
     with requests_mock.Mocker() as m:
+        m.get(HOST, text=CSRF_PAGE)
         m.post(f"{HOST}/login", json={ApiFields.SUCCESS: True}, cookies={"3x-ui": SESSION})
         api = Api(HOST, "username", "password")
         api.login()
@@ -29,6 +32,7 @@ def test_login_success():
 
 def test_login_failed():
     with requests_mock.Mocker() as m:
+        m.get(HOST, text=CSRF_PAGE)
         m.post(f"{HOST}/login", json={ApiFields.SUCCESS: False})
         api = Api(HOST, "username", "password")
         with pytest.raises(ValueError):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,6 +43,36 @@ def test_login_failed():
             api.client.login()
 
 
+def test_login_failed_without_csrf_token():
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{HOST}/csrf-token",
+            json={ApiFields.SUCCESS: True, ApiFields.OBJ: None},
+        )
+        m.post(f"{HOST}/login", json={ApiFields.SUCCESS: True})
+        api = Api(HOST, "username", "password")
+
+        with pytest.raises(ValueError):
+            api.login()
+
+        assert len(m.request_history) == 1
+
+
+def test_logged_in_requests_include_csrf_header():
+    response_example = json.load(open(os.path.join(RESPONSES_DIR, "get_inbounds.json")))
+
+    with requests_mock.Mocker() as m:
+        m.get(f"{HOST}/csrf-token", json=CSRF_RESPONSE, cookies={"3x-ui": SESSION})
+        m.post(f"{HOST}/login", json={ApiFields.SUCCESS: True}, cookies={"3x-ui": SESSION})
+        m.get(f"{HOST}/panel/api/inbounds/list", json=response_example)
+
+        api = Api(HOST, "username", "password")
+        api.login()
+        api.inbound.get_list()
+
+        assert m.request_history[2].headers["X-CSRF-Token"] == CSRF_TOKEN
+
+
 def test_from_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("XUI_HOST", HOST)
     monkeypatch.setenv("XUI_USERNAME", USERNAME)
@@ -67,6 +97,16 @@ def test_from_env_token(monkeypatch: pytest.MonkeyPatch):
     assert api.inbound.username is None
     assert api.inbound.password is None
     assert api.inbound.token == TOKEN
+
+
+def test_from_env_requires_credentials_without_token(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("XUI_HOST", HOST)
+    monkeypatch.delenv("XUI_USERNAME", raising=False)
+    monkeypatch.delenv("XUI_PASSWORD", raising=False)
+    monkeypatch.delenv("XUI_TOKEN", raising=False)
+
+    with pytest.raises(ValueError):
+        Api.from_env()
 
 
 def test_token_auth_uses_authorization_header():

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -15,6 +15,8 @@ HOST = "http://localhost"
 USERNAME = "admin"
 PASSWORD = "admin"
 SESSION = "abc123"
+CSRF_TOKEN = "test-csrf-token"
+CSRF_PAGE = f'<input type="hidden" name="csrf_token" value="{CSRF_TOKEN}">'
 EMAIL = "alhtim2x"
 RESPONSES_DIR = "tests/responses"
 HOST = "http://localhost"
@@ -38,6 +40,12 @@ async def test_from_env():
 @pytest.mark.asyncio
 async def test_login_failed(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
+        method="GET",
+        url=HOST,
+        text=CSRF_PAGE,
+        status_code=200,
+    )
+    httpx_mock.add_response(
         method="POST",
         url=f"{HOST}/login",
         json={ApiFields.SUCCESS: False},
@@ -51,6 +59,12 @@ async def test_login_failed(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_login_success(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        method="GET",
+        url=HOST,
+        text=CSRF_PAGE,
+        status_code=200,
+    )
     httpx_mock.add_response(
         method="POST",
         url=f"{HOST}/login",

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -15,6 +15,7 @@ HOST = "http://localhost"
 USERNAME = "admin"
 PASSWORD = "admin"
 SESSION = "abc123"
+CSRF_TOKEN = "test-csrf-token"
 CSRF_RESPONSE = {ApiFields.SUCCESS: True, ApiFields.OBJ: CSRF_TOKEN}
 EMAIL = "alhtim2x"
 RESPONSES_DIR = "tests/responses"
@@ -32,8 +33,12 @@ async def test_from_env():
 
     api = AsyncApi.from_env()
     assert api.inbound.host == HOST, f"Expected {HOST}, got {api.inbound.host}"
-    assert api.inbound.username == USERNAME, f"Expected {USERNAME}, got {api.inbound.username}"
-    assert api.inbound.password == PASSWORD, f"Expected {PASSWORD}, got {api.inbound.password}"
+    assert api.inbound.username == USERNAME, (
+        f"Expected {USERNAME}, got {api.inbound.username}"
+    )
+    assert api.inbound.password == PASSWORD, (
+        f"Expected {PASSWORD}, got {api.inbound.password}"
+    )
 
 
 @pytest.mark.asyncio
@@ -273,7 +278,9 @@ async def test_client_online(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_get_client_traffic_by_id(httpx_mock: HTTPXMock):
-    response_example = json.load(open(os.path.join(RESPONSES_DIR, "get_client_traffic_by_id.json")))
+    response_example = json.load(
+        open(os.path.join(RESPONSES_DIR, "get_client_traffic_by_id.json"))
+    )
 
     httpx_mock.add_response(
         method="GET",
@@ -305,7 +312,9 @@ def _prepare_inbound() -> Inbound:
         "acceptProxyProtocol": False,
         "header": {"type": "none"},
     }
-    stream_settings = StreamSettings(security="reality", network="tcp", tcp_settings=tcp_settings)
+    stream_settings = StreamSettings(
+        security="reality", network="tcp", tcp_settings=tcp_settings
+    )
 
     inbound = Inbound(
         enable=True,
@@ -338,16 +347,16 @@ async def test_get_inbounds(httpx_mock: HTTPXMock):
     assert len(inbounds) == 1, f"Expected 1, got {len(inbounds)}"
     inbound = inbounds[0]
     assert isinstance(inbound, Inbound), f"Expected Inbound, got {type(inbound)}"
-    assert isinstance(
-        inbound.stream_settings, (StreamSettings, str)
-    ), f"Expected StreamSettings or str, got {type(inbound.stream_settings)}"
+    assert isinstance(inbound.stream_settings, (StreamSettings, str)), (
+        f"Expected StreamSettings or str, got {type(inbound.stream_settings)}"
+    )
 
-    assert isinstance(
-        inbound.sniffing, Sniffing
-    ), f"Expected Sniffing, got {type(inbound.sniffing)}"
-    assert isinstance(
-        inbound.client_stats[0], Client
-    ), f"Expected ClientStats, got {type(inbound.client_stats[0])}"
+    assert isinstance(inbound.sniffing, Sniffing), (
+        f"Expected Sniffing, got {type(inbound.sniffing)}"
+    )
+    assert isinstance(inbound.client_stats[0], Client), (
+        f"Expected ClientStats, got {type(inbound.client_stats[0])}"
+    )
 
     assert inbound.id == 1, f"Expected 1, got {inbound.id}"
 
@@ -390,7 +399,10 @@ async def test_delete_inbound_success(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_delete_inbound_failed(httpx_mock: HTTPXMock):
-    response_example = {ApiFields.SUCCESS: False, ApiFields.MSG: "Delete Failed: record not found"}
+    response_example = {
+        ApiFields.SUCCESS: False,
+        ApiFields.MSG: "Delete Failed: record not found",
+    }
 
     httpx_mock.add_response(
         method="POST",
@@ -448,7 +460,9 @@ async def test_get_server_status(httpx_mock: HTTPXMock):
     """
     Test for checking server status retrieval
     """
-    response_example = json.load(open(os.path.join(RESPONSES_DIR, "get_server_status.json")))
+    response_example = json.load(
+        open(os.path.join(RESPONSES_DIR, "get_server_status.json"))
+    )
 
     httpx_mock.add_response(
         method="GET",
@@ -463,10 +477,12 @@ async def test_get_server_status(httpx_mock: HTTPXMock):
 
     assert httpx_mock.get_request(), "Mocked request was not called"
     assert status.cpu == 5.2, f"Expected CPU 5.2, got {status.cpu}"
-    assert (
-        status.mem.current == 1024000
-    ), f"Expected current memory usage 1024, got {status.mem.current}"
-    assert status.mem.total == 8192000, f"Expected total memory 8192, got {status.mem.total}"
+    assert status.mem.current == 1024000, (
+        f"Expected current memory usage 1024, got {status.mem.current}"
+    )
+    assert status.mem.total == 8192000, (
+        f"Expected total memory 8192, got {status.mem.total}"
+    )
 
 
 @pytest.mark.asyncio
@@ -547,7 +563,9 @@ async def test_get_db_failed(httpx_mock: HTTPXMock, tmp_path):
 
 @pytest.mark.asyncio
 async def test_get_inbound_by_id(httpx_mock: HTTPXMock):
-    response_example = json.load(open(os.path.join(RESPONSES_DIR, "get_inbound_by_id.json")))
+    response_example = json.load(
+        open(os.path.join(RESPONSES_DIR, "get_inbound_by_id.json"))
+    )
 
     httpx_mock.add_response(
         method="GET",
@@ -563,13 +581,15 @@ async def test_get_inbound_by_id(httpx_mock: HTTPXMock):
     assert httpx_mock.get_request(), "Mocked request was not called"
     assert isinstance(inbound, Inbound), f"Expected Inbound, got {type(inbound)}"
     assert inbound.id == 1, f"Expected 1, got {inbound.id}"
-    assert inbound.remark == "test-inbound", f"Expected 'test-inbound', got {inbound.remark}"
+    assert inbound.remark == "test-inbound", (
+        f"Expected 'test-inbound', got {inbound.remark}"
+    )
     assert inbound.port == 37316, f"Expected 37316, got {inbound.port}"
     assert inbound.protocol == "vless", f"Expected 'vless', got {inbound.protocol}"
     assert inbound.enable is True, f"Expected True, got {inbound.enable}"
-    assert isinstance(
-        inbound.client_stats[0], Client
-    ), f"Expected Client, got {type(inbound.client_stats[0])}"
+    assert isinstance(inbound.client_stats[0], Client), (
+        f"Expected Client, got {type(inbound.client_stats[0])}"
+    )
 
 
 @pytest.mark.asyncio
@@ -618,7 +638,7 @@ async def test_get_xray_version_available(httpx_mock: HTTPXMock):
         ApiFields.MSG: "",
         ApiFields.OBJ: ["1.5.0"],
     }
-    
+
     httpx_mock.add_response(
         method="GET",
         url=f"{HOST}/panel/api/server/getXrayVersion",
@@ -635,7 +655,6 @@ async def test_get_xray_version_available(httpx_mock: HTTPXMock):
     assert xray_versions == response_example_xray_available[ApiFields.OBJ]
 
 
-
 @pytest.mark.asyncio
 async def test_get_xray_version_unavailable(httpx_mock: HTTPXMock):
     """
@@ -646,14 +665,14 @@ async def test_get_xray_version_unavailable(httpx_mock: HTTPXMock):
         ApiFields.MSG: "",
         ApiFields.OBJ: None,
     }
-    
+
     httpx_mock.add_response(
         method="GET",
         url=f"{HOST}/panel/api/server/getXrayVersion",
         json=response_example_xray_unavailable,
         status_code=200,
     )
-        
+
     api = AsyncApi(HOST, USERNAME, PASSWORD)
     api.session = SESSION
 
@@ -673,14 +692,14 @@ async def test_install_new_xray_version_unavailable(httpx_mock: HTTPXMock):
         ApiFields.MSG: "",
         ApiFields.OBJ: None,
     }
-    
+
     httpx_mock.add_response(
         method="POST",
         url=f"{HOST}/panel/api/server/installXray/1.5.0",
         json=response_example,
         status_code=200,
     )
-    
+
     api = AsyncApi(HOST, USERNAME, PASSWORD)
     api.session = SESSION
     await api.server.install_new_xray_version("1.5.0")
@@ -698,7 +717,7 @@ async def test_install_new_xray_version_failed(httpx_mock: HTTPXMock):
         ApiFields.MSG: "",
         ApiFields.OBJ: None,
     }
-    
+
     httpx_mock.add_response(
         method="POST",
         url=f"{HOST}/panel/api/server/installXray/1.5.0",
@@ -713,7 +732,6 @@ async def test_install_new_xray_version_failed(httpx_mock: HTTPXMock):
         await api.server.install_new_xray_version("1.5.0")
 
     assert httpx_mock.get_request(), "Mocked request was not called"
-
 
 
 @pytest.mark.asyncio
@@ -763,7 +781,9 @@ async def test_get_server_config(httpx_mock: HTTPXMock):
     """
     Test for getting server config
     """
-    response_example = json.load(open(os.path.join(RESPONSES_DIR, "get_server_config.json")))
+    response_example = json.load(
+        open(os.path.join(RESPONSES_DIR, "get_server_config.json"))
+    )
 
     httpx_mock.add_response(
         method="GET",
@@ -778,5 +798,9 @@ async def test_get_server_config(httpx_mock: HTTPXMock):
     config = await api.server.get_server_config()
 
     assert config is not None, "Expected config, got None"
-    assert isinstance(config.inbounds, list), f"Expected list of inbounds, got {type(config.inbounds)}"
-    assert config.log.access == "none", f"Expected access log 'none', got {config.log.access}"
+    assert isinstance(config.inbounds, list), (
+        f"Expected list of inbounds, got {type(config.inbounds)}"
+    )
+    assert config.log.access == "none", (
+        f"Expected access log 'none', got {config.log.access}"
+    )

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -17,6 +17,7 @@ PASSWORD = "admin"
 SESSION = "abc123"
 CSRF_TOKEN = "test-csrf-token"
 CSRF_PAGE = f'<input type="hidden" name="csrf_token" value="{CSRF_TOKEN}">'
+CSRF_RESPONSE = {ApiFields.SUCCESS: True, ApiFields.OBJ: CSRF_TOKEN}
 EMAIL = "alhtim2x"
 RESPONSES_DIR = "tests/responses"
 HOST = "http://localhost"
@@ -41,8 +42,8 @@ async def test_from_env():
 async def test_login_failed(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         method="GET",
-        url=HOST,
-        text=CSRF_PAGE,
+        url=f"{HOST}/csrf-token",
+        json=CSRF_RESPONSE,
         status_code=200,
     )
     httpx_mock.add_response(
@@ -61,8 +62,8 @@ async def test_login_failed(httpx_mock: HTTPXMock):
 async def test_login_success(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         method="GET",
-        url=HOST,
-        text=CSRF_PAGE,
+        url=f"{HOST}/csrf-token",
+        json=CSRF_RESPONSE,
         status_code=200,
     )
     httpx_mock.add_response(
@@ -76,6 +77,29 @@ async def test_login_success(httpx_mock: HTTPXMock):
     api = AsyncApi(HOST, "username", "password")
     await api.login()
     assert api.session == SESSION, f"Expected {SESSION}, got {api.session}"
+
+
+@pytest.mark.asyncio
+async def test_login_sends_csrf_header(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{HOST}/csrf-token",
+        json=CSRF_RESPONSE,
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{HOST}/login",
+        json={ApiFields.SUCCESS: True},
+        status_code=200,
+        headers={"Set-Cookie": f"3x-ui={SESSION}; Path=/"},
+    )
+
+    api = AsyncApi(HOST, "username", "password")
+    await api.login()
+
+    login_request = httpx_mock.get_requests()[1]
+    assert login_request.headers["X-CSRF-Token"] == CSRF_TOKEN
 
 
 @pytest.mark.asyncio

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -15,8 +15,6 @@ HOST = "http://localhost"
 USERNAME = "admin"
 PASSWORD = "admin"
 SESSION = "abc123"
-CSRF_TOKEN = "test-csrf-token"
-CSRF_PAGE = f'<input type="hidden" name="csrf_token" value="{CSRF_TOKEN}">'
 CSRF_RESPONSE = {ApiFields.SUCCESS: True, ApiFields.OBJ: CSRF_TOKEN}
 EMAIL = "alhtim2x"
 RESPONSES_DIR = "tests/responses"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -20,9 +20,19 @@ def test_envs_success():
 def test_envs_failed():
     os.environ["ABCDEF"] = "http://localhost"
     os.environ.pop("XUI_HOST", None)
+    os.environ.pop("XUI_USERNAME", None)
+    os.environ.pop("XUI_PASSWORD", None)
     os.environ.pop("XUI_TOKEN", None)
 
     with pytest.raises(ValueError):
         env.xui_host()
 
     assert env.xui_token() is None
+    assert env.xui_username() is None
+    assert env.xui_password() is None
+
+    with pytest.raises(ValueError):
+        env.xui_username(raise_if_not_found=True)
+
+    with pytest.raises(ValueError):
+        env.xui_password(raise_if_not_found=True)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -9,15 +9,20 @@ def test_envs_success():
     os.environ["XUI_HOST"] = "http://localhost"
     os.environ["XUI_USERNAME"] = "admin"
     os.environ["XUI_PASSWORD"] = "admin"
+    os.environ["XUI_TOKEN"] = "token"
 
     assert env.xui_host() == "http://localhost"
     assert env.xui_username() == "admin"
     assert env.xui_password() == "admin"
+    assert env.xui_token() == "token"
 
 
 def test_envs_failed():
     os.environ["ABCDEF"] = "http://localhost"
     os.environ.pop("XUI_HOST", None)
+    os.environ.pop("XUI_TOKEN", None)
 
     with pytest.raises(ValueError):
         env.xui_host()
+
+    assert env.xui_token() is None

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,4 +1,3 @@
-from multiprocessing import Value
 import os
 
 import pytest

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,3 +1,4 @@
+from multiprocessing import Value
 import os
 
 import pytest
@@ -28,8 +29,6 @@ def test_envs_failed():
         env.xui_host()
 
     assert env.xui_token() is None
-    assert env.xui_username() is None
-    assert env.xui_password() is None
 
     with pytest.raises(ValueError):
         env.xui_username(raise_if_not_found=True)


### PR DESCRIPTION
## Description
Update to 3x-ui 3.0.0 where CSRF token must be used.
Now when logging, It gets CSRF token before POST requests to /login.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing
- [X] I have tested my changes locally
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All existing tests pass
- [X] My changes generate no new warnings

## Checklist
- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
